### PR TITLE
Hot path: generate from binary dictionaries (byte-identical slugs)

### DIFF
--- a/slugkit/include/slugkit/generator/binary_dictionary.hpp
+++ b/slugkit/include/slugkit/generator/binary_dictionary.hpp
@@ -6,6 +6,11 @@
 
 #include <fmt/format.h>
 
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
 /*
 See docs/binary_dictionary_format.md for the file layout.
 */
@@ -17,11 +22,14 @@ public:
     FilteredDictionary(
         filter::IndexSequence indices,
         const detail::IndexTable* index_table,
-        const detail::WordData* word_data
+        const detail::WordData* word_data,
+        CaseType case_type = CaseType::kNone
     )
         : indices_(std::move(indices))
         , index_table_(index_table)
-        , word_data_(word_data) {
+        , word_data_(word_data)
+        , case_type_(case_type)
+        , max_length_(ComputeMaxLength()) {
         assert(index_table_ != nullptr);
         assert(word_data_ != nullptr);
     }
@@ -36,15 +44,33 @@ public:
         return indices_.empty();
     }
 
+    /// @brief The selector's case; the substitution generator picks the matching precomputed
+    /// word variant (kMixed uses the lowercase variant plus a per-word case mask).
+    [[nodiscard]] auto GetCase() const noexcept -> CaseType {
+        return case_type_;
+    }
+
+    /// @brief The maximum byte length among the filtered words (matches the in-memory
+    /// FilteredDictionary: max over the filtered set, used for the mixed-case mask and the
+    /// pattern's max-length estimate).
+    [[nodiscard]] auto GetMaxLength() const noexcept -> std::size_t {
+        return max_length_;
+    }
+
     auto operator[](IndexType index) const -> const WordEntry&;
 
 private:
+    auto ComputeMaxLength() const -> std::size_t;
+
     filter::IndexSequence indices_;
     const detail::IndexTable* index_table_;
     const detail::WordData* word_data_;
+    CaseType case_type_;
+    std::size_t max_length_;
 };
 
 using FilteredDictionaryPtr = std::shared_ptr<FilteredDictionary>;
+using FilteredDictionaryConstPtr = std::shared_ptr<const FilteredDictionary>;
 
 /// @brief A binary dictionary is an interface to a binary memory-mapped dictionary file
 ///        or a memory region that contains a dictionary.
@@ -96,6 +122,46 @@ private:
     const detail::LanguageTable* language_table_;
     const detail::TagsTable* tags_table_;
     const detail::WordData* word_data_;
+};
+
+/// @brief A set of binary dictionaries keyed by kind, the binary counterpart of
+/// generator::DictionarySet. Each BinaryDictionary already holds all languages for its kind,
+/// so the set keys by kind only and defers language selection to the dictionary.
+/// @note The set retains a keepalive for each dictionary's backing bytes (e.g. a memory
+/// mapping), so the mapped data outlives the dictionaries that view it.
+class DictionarySet {
+public:
+    using RawData = BinaryDictionary::RawData;
+
+    DictionarySet() = default;
+
+    /// @brief Add a dictionary over @c data. @c keepalive owns the bytes and is retained so
+    /// they outlive the dictionary (e.g. a shared_ptr to a memory-mapped file). The
+    /// dictionary is keyed by its Kind(). Throws if @c data is not a valid dictionary.
+    void Add(RawData data, std::shared_ptr<void> keepalive);
+
+    /// @brief Filter by selector, dispatching on kind. Mirrors the in-memory DictionarySet:
+    /// a selector with no language defaults to "en"; an unknown kind or language yields an
+    /// empty result (rather than throwing).
+    [[nodiscard]] auto Filter(const Selector& selector) const -> FilteredDictionaryPtr;
+
+    [[nodiscard]] auto Contains(std::string_view kind) const -> bool {
+        return dictionaries_.find(std::string{kind}) != dictionaries_.end();
+    }
+
+    [[nodiscard]] auto size() const noexcept -> std::size_t {
+        return dictionaries_.size();
+    }
+
+    [[nodiscard]] auto empty() const noexcept -> bool {
+        return dictionaries_.empty();
+    }
+
+private:
+    static constexpr std::string_view kDefaultLanguage = "en";
+
+    std::map<std::string, BinaryDictionary> dictionaries_;
+    std::vector<std::shared_ptr<void>> keepalives_;
 };
 
 }  // namespace slugkit::generator::binary

--- a/slugkit/include/slugkit/generator/generator.hpp
+++ b/slugkit/include/slugkit/generator/generator.hpp
@@ -14,13 +14,21 @@
 
 namespace slugkit::generator {
 
+namespace binary {
+class DictionarySet;
+}  // namespace binary
+
 using GenerateCallback = std::function<void(std::string generated_slug)>;
 
 /// @brief A generator is a class that generates human-readable IDs.
 /// TODO move to a separate file
 class Generator {
 public:
+    /// @brief Construct from an in-memory dictionary set (YAML/JSON-loaded).
     Generator(DictionarySet dictionaries);
+    /// @brief Construct from a binary (memory-mapped) dictionary set. Produces byte-identical
+    /// slugs to the in-memory set built from the same data.
+    Generator(binary::DictionarySet dictionaries);
     ~Generator() noexcept;
 
     [[nodiscard]] auto RandomSeed() const -> std::string;
@@ -130,7 +138,8 @@ public:
     }
 
 private:
-    constexpr static std::size_t kImplSize = 96;
+    // Holds a variant of the in-memory and binary dictionary sets.
+    constexpr static std::size_t kImplSize = 144;
     constexpr static std::size_t kImplAlign = 8;
     struct Impl;
     userver::utils::FastPimpl<Impl, kImplSize, kImplAlign> impl_;

--- a/slugkit/src/slugkit/generator/binary_dictionary.cpp
+++ b/slugkit/src/slugkit/generator/binary_dictionary.cpp
@@ -2,6 +2,8 @@
 
 #include <slugkit/generator/exceptions.hpp>
 
+#include <slugkit/utils/text.hpp>
+
 #include <algorithm>
 
 namespace slugkit::generator::binary {
@@ -549,6 +551,17 @@ auto FilteredDictionary::operator[](IndexType index) const -> const WordEntry& {
     return word_data_->At(offset);
 }
 
+auto FilteredDictionary::ComputeMaxLength() const -> std::size_t {
+    // Max byte length over the filtered words, matching the in-memory FilteredDictionary.
+    std::size_t max_length = 0;
+    const auto count = indices_.count().GetUnderlying();
+    for (IndexType::UnderlyingType i = 0; i < count; ++i) {
+        const auto offset = (*index_table_)[indices_.at(IndexType(i))];
+        max_length = std::max(max_length, word_data_->At(offset).Lowercase().size());
+    }
+    return max_length;
+}
+
 //-----------------------------------------------------------------------------
 // BinaryDictionary
 //-----------------------------------------------------------------------------
@@ -604,7 +617,39 @@ auto BinaryDictionary::Filter(const Selector& selector) const -> FilteredDiction
     auto index_sequence = language_table_->Filter(selector.language, selector.size_limit);
     auto indices = tags_table_->Filter(index_sequence, selector.include_tags, selector.exclude_tags);
     // TODO opt-in tags
-    return std::make_shared<FilteredDictionary>(indices, index_table_, word_data_);
+    return std::make_shared<FilteredDictionary>(indices, index_table_, word_data_, selector.GetCase());
+}
+
+//-----------------------------------------------------------------------------
+// DictionarySet
+//-----------------------------------------------------------------------------
+void DictionarySet::Add(RawData data, std::shared_ptr<void> keepalive) {
+    BinaryDictionary dictionary(data);
+    auto kind = utils::text::ToLower(dictionary.Kind(), utils::text::kEnUsLocale);
+    keepalives_.push_back(std::move(keepalive));
+    dictionaries_.insert_or_assign(std::move(kind), std::move(dictionary));
+}
+
+auto DictionarySet::Filter(const Selector& selector) const -> FilteredDictionaryPtr {
+    auto kind = utils::text::ToLower(selector.kind, utils::text::kEnUsLocale);
+    auto it = dictionaries_.find(kind);
+    if (it == dictionaries_.end()) {
+        return {};
+    }
+    const auto& dictionary = it->second;
+
+    // Determine the effective language: explicit on the selector, else default to "en"
+    // (matching the in-memory DictionarySet's language-specific default). An unknown
+    // language yields an empty result rather than throwing, again matching the in-memory set.
+    Selector effective = selector;
+    if (!effective.language) {
+        effective.language = LanguageCodeView{kDefaultLanguage};
+    }
+    const auto languages = dictionary.Languages();
+    if (languages.find(*effective.language) == languages.end()) {
+        return {};
+    }
+    return dictionary.Filter(effective);
 }
 
 }  // namespace slugkit::generator::binary

--- a/slugkit/src/slugkit/generator/generator.cpp
+++ b/slugkit/src/slugkit/generator/generator.cpp
@@ -1,18 +1,24 @@
 #include <slugkit/generator/generator.hpp>
 
+#include <slugkit/generator/binary_dictionary.hpp>
 #include <slugkit/generator/exceptions.hpp>
 #include <slugkit/generator/pattern_generator.hpp>
 
 #include <random>
+#include <variant>
 
 namespace slugkit::generator {
 
 struct Generator::Impl {
-    DictionarySet dictionaries;
+    // The generator works with either an in-memory or a binary (memory-mapped) dictionary
+    // set; PatternGenerator accepts both and produces byte-identical slugs.
+    std::variant<DictionarySet, binary::DictionarySet> dictionaries;
 
     PatternSettings GetCapacity(PatternPtr pattern) const {
         // TODO LRU cache for pattern generators
-        return PatternGenerator(dictionaries, pattern).GetSettings();
+        return std::visit(
+            [&](const auto& dict) { return PatternGenerator(dict, pattern).GetSettings(); }, dictionaries
+        );
     }
 
     std::string Generate(std::string_view pattern_str, std::string_view seed, std::size_t sequence_number) const {
@@ -21,8 +27,13 @@ struct Generator::Impl {
     }
 
     std::string Generate(PatternPtr pattern, std::string_view seed, std::size_t sequence_number) const {
-        auto generator = PatternGenerator(dictionaries, pattern);
-        return generator(seed, sequence_number);
+        return std::visit(
+            [&](const auto& dict) {
+                auto generator = PatternGenerator(dict, pattern);
+                return generator(seed, sequence_number);
+            },
+            dictionaries
+        );
     }
 
     std::string Generate(
@@ -32,8 +43,13 @@ struct Generator::Impl {
         std::size_t sequence_number
     ) const {
         // TODO LRU cache for pattern generators
-        auto generator = PatternGenerator(dictionaries, pattern, settings);
-        return generator(seed, sequence_number);
+        return std::visit(
+            [&](const auto& dict) {
+                auto generator = PatternGenerator(dict, pattern, settings);
+                return generator(seed, sequence_number);
+            },
+            dictionaries
+        );
     }
 
     void Generate(
@@ -54,11 +70,16 @@ struct Generator::Impl {
         std::size_t count,
         GenerateCallback callback
     ) const {
-        auto generator = PatternGenerator(dictionaries, pattern);
-        auto seed_hash = PatternGenerator::SeedHash(seed);
-        for (std::size_t i = 0; i < count; ++i) {
-            callback(generator(seed_hash, sequence_number + i));
-        }
+        std::visit(
+            [&](const auto& dict) {
+                auto generator = PatternGenerator(dict, pattern);
+                auto seed_hash = PatternGenerator::SeedHash(seed);
+                for (std::size_t i = 0; i < count; ++i) {
+                    callback(generator(seed_hash, sequence_number + i));
+                }
+            },
+            dictionaries
+        );
     }
 
     void Generate(
@@ -70,17 +91,26 @@ struct Generator::Impl {
         GenerateCallback callback
     ) const {
         // TODO LRU cache for pattern generators
-        auto generator = PatternGenerator(dictionaries, pattern, settings);
-        auto seed_hash = PatternGenerator::SeedHash(seed);
-        for (std::size_t i = 0; i < count; ++i) {
-            callback(generator(seed_hash, sequence_number + i));
-        }
+        std::visit(
+            [&](const auto& dict) {
+                auto generator = PatternGenerator(dict, pattern, settings);
+                auto seed_hash = PatternGenerator::SeedHash(seed);
+                for (std::size_t i = 0; i < count; ++i) {
+                    callback(generator(seed_hash, sequence_number + i));
+                }
+            },
+            dictionaries
+        );
     }
 };
 
 //--------------------------------
 
 Generator::Generator(DictionarySet dictionaries)
+    : impl_{std::move(dictionaries)} {
+}
+
+Generator::Generator(binary::DictionarySet dictionaries)
     : impl_{std::move(dictionaries)} {
 }
 

--- a/slugkit/src/slugkit/generator/pattern_generator.cpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.cpp
@@ -111,6 +111,48 @@ std::size_t SelectorSubstitutionGenerator::GetMaxLength() const {
 }
 
 //-------------------------------------------------------------
+// BinarySelectorSubstitutionGenerator
+//-------------------------------------------------------------
+BinarySelectorSubstitutionGenerator::BinarySelectorSubstitutionGenerator(
+    binary::FilteredDictionaryConstPtr dictionary,
+    const SelectorSettings& settings
+)
+    : dictionary_{std::move(dictionary)}
+    , selected_size_{settings.selected_size} {
+}
+
+std::string BinarySelectorSubstitutionGenerator::Generate(std::uint32_t seed, std::size_t sequence_number) const {
+    auto index = Permute(selected_size_, seed, sequence_number);
+    const auto& entry = (*dictionary_)[IndexType(static_cast<IndexType::UnderlyingType>(index))];
+    // The dictionary stores precomputed case variants, so pick the matching one instead of
+    // converting at generation time. kMixed uses the lowercase variant plus a per-word mask.
+    switch (dictionary_->GetCase()) {
+        case CaseType::kUpper:
+            return std::string{entry.Uppercase()};
+        case CaseType::kTitle:
+            return std::string{entry.Titlecase()};
+        case CaseType::kMixed: {
+            auto word = entry.Lowercase();
+            std::uint64_t max_mask_value = 1ULL << dictionary_->GetMaxLength();
+            if (max_mask_value < 2) {
+                // Guard against FPE in __builtin_clzll when the longest word is 1 character.
+                max_mask_value = 2;
+            }
+            utils::text::CaseMask mask{PermutePowerOf2(max_mask_value, seed, sequence_number)};
+            return utils::text::MixedCase(word, utils::text::kEnUsLocale, mask);
+        }
+        case CaseType::kNone:
+        case CaseType::kLower:
+        default:
+            return std::string{entry.Lowercase()};
+    }
+}
+
+std::size_t BinarySelectorSubstitutionGenerator::GetMaxLength() const {
+    return dictionary_->GetMaxLength();
+}
+
+//-------------------------------------------------------------
 // NumberSubstitutionGenerator
 //-------------------------------------------------------------
 NumberSubstitutionGenerator::NumberSubstitutionGenerator(const NumberGen& number_gen)
@@ -307,6 +349,23 @@ numeric::BigInt EmojiSubstitutionGenerator::GetCapacity() const {
 //-------------------------------------------------------------
 // PatternGenerator::Impl
 //-------------------------------------------------------------
+namespace {
+
+// Build the selector substitution generator appropriate to the filtered-dictionary type, so
+// the otherwise-identical settings/init logic can be shared between the in-memory and binary
+// dictionary sets.
+auto MakeSelectorGenerator(FilteredDictionaryConstPtr dictionary, const SelectorSettings& settings)
+    -> SubstitutionGeneratorPtr {
+    return std::make_unique<SelectorSubstitutionGenerator>(std::move(dictionary), settings);
+}
+
+auto MakeSelectorGenerator(binary::FilteredDictionaryConstPtr dictionary, const SelectorSettings& settings)
+    -> SubstitutionGeneratorPtr {
+    return std::make_unique<BinarySelectorSubstitutionGenerator>(std::move(dictionary), settings);
+}
+
+}  // namespace
+
 struct PatternGenerator::Impl {
     PatternPtr pattern;
     std::string seed;
@@ -329,13 +388,32 @@ struct PatternGenerator::Impl {
         InitGenerators(dictionaries);
     }
 
+    // Binary dictionary set overloads: the binary dictionaries reproduce the in-memory
+    // dictionaries' lexicographic order, so the same settings/init logic applies and the
+    // generated slugs are byte-identical.
+    Impl(const binary::DictionarySet& dictionaries, PatternPtr pattern)
+        : pattern{pattern}
+        , generators{}
+        , settings{CalculateSettings(dictionaries)} {
+        //
+    }
+
+    Impl(const binary::DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings)
+        : pattern{pattern}
+        , generators{}
+        , settings{settings} {
+        InitGenerators(dictionaries);
+    }
+
     // This function has a side effect of initializing the generators
-    PatternSettings CalculateSettings(const DictionarySet& dictionaries) {
+    template <typename DictSet>
+    PatternSettings CalculateSettings(const DictSet& dictionaries) {
         numeric::BigInt capacity(1);
         std::size_t max_pattern_length = pattern->ArbitraryTextLength();
 
         std::vector<SelectorSettings> selectors;
-        std::map<std::int64_t, FilteredDictionaryConstPtr> filtered_dictionaries;
+        using FilteredPtr = decltype(dictionaries.Filter(std::declval<const Selector&>()));
+        std::map<std::int64_t, FilteredPtr> filtered_dictionaries;
 
         for (const auto& element : pattern->placeholders) {
             if (std::holds_alternative<Selector>(element)) {
@@ -366,7 +444,7 @@ struct PatternGenerator::Impl {
                     }
                 }
                 selectors.push_back(settings);
-                generators.push_back(std::make_unique<SelectorSubstitutionGenerator>(filtered_dict, settings));
+                generators.push_back(MakeSelectorGenerator(filtered_dict, settings));
             } else if (std::holds_alternative<NumberGen>(element)) {
                 const auto& number_gen = std::get<NumberGen>(element);
                 if (number_gen.base == NumberBase::kRoman || number_gen.base == NumberBase::kRomanLower) {
@@ -387,7 +465,8 @@ struct PatternGenerator::Impl {
         return PatternSettings{selectors, capacity, static_cast<std::uint8_t>(max_pattern_length)};
     }
 
-    void InitGenerators(const DictionarySet& dictionaries) {
+    template <typename DictSet>
+    void InitGenerators(const DictSet& dictionaries) {
         auto selector_settings = settings.selectors.begin();
         numeric::BigInt capacity{1};
         std::size_t max_pattern_length = pattern->ArbitraryTextLength();
@@ -401,8 +480,7 @@ struct PatternGenerator::Impl {
                 if (!filtered_dict || filtered_dict->empty()) {
                     throw PatternSyntaxError("No matching words found for: " + selector.ToString());
                 }
-                generators.push_back(std::make_unique<SelectorSubstitutionGenerator>(filtered_dict, *selector_settings)
-                );
+                generators.push_back(MakeSelectorGenerator(filtered_dict, *selector_settings));
                 ++selector_settings;
             } else if (std::holds_alternative<NumberGen>(element)) {
                 const auto& number_gen = std::get<NumberGen>(element);
@@ -444,6 +522,18 @@ PatternGenerator::PatternGenerator(const DictionarySet& dictionaries, PatternPtr
 }
 
 PatternGenerator::PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings)
+    : impl_{dictionaries, pattern, settings} {
+}
+
+PatternGenerator::PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern)
+    : impl_{dictionaries, pattern} {
+}
+
+PatternGenerator::PatternGenerator(
+    const binary::DictionarySet& dictionaries,
+    PatternPtr pattern,
+    PatternSettings settings
+)
     : impl_{dictionaries, pattern, settings} {
 }
 

--- a/slugkit/src/slugkit/generator/pattern_generator.hpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <slugkit/generator/binary_dictionary.hpp>
 #include <slugkit/generator/dictionary.hpp>
 #include <slugkit/generator/generator.hpp>
 #include <slugkit/generator/pattern.hpp>
@@ -47,6 +48,28 @@ public:
 
 private:
     FilteredDictionaryConstPtr dictionary_;
+    std::int64_t selected_size_;
+};
+
+/// @brief Selector substitution generator backed by a memory-mapped binary dictionary.
+/// Functionally identical to SelectorSubstitutionGenerator but consumes binary::WordEntry
+/// precomputed case variants (string_views) instead of the std::string-returning in-memory
+/// FilteredDictionary, so it produces byte-identical slugs without per-word case conversion
+/// (kMixed uses the lowercase variant plus a per-word case mask).
+class BinarySelectorSubstitutionGenerator : public SubstitutionGenerator {
+public:
+    BinarySelectorSubstitutionGenerator(binary::FilteredDictionaryConstPtr dictionary, const SelectorSettings& settings);
+    ~BinarySelectorSubstitutionGenerator() override = default;
+
+    std::string Generate(std::uint32_t seed, std::size_t sequence_number) const override;
+
+    numeric::BigInt GetCapacity() const override {
+        return numeric::BigInt(selected_size_);
+    }
+    std::size_t GetMaxLength() const override;
+
+private:
+    binary::FilteredDictionaryConstPtr dictionary_;
     std::int64_t selected_size_;
 };
 
@@ -163,6 +186,8 @@ class PatternGenerator {
 public:
     PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern);
     PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings);
+    PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern);
+    PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings);
     ~PatternGenerator();
 
     /// @brief Generate a string from a pattern

--- a/slugkit/tests/CMakeLists.txt
+++ b/slugkit/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(${PROJECT_NAME}_TEST_SRC
     ${TEST_SRC_ROOT}/sructrured_loading_test.cpp
     ${TEST_SRC_ROOT}/emoji_generator_test.cpp
     ${TEST_SRC_ROOT}/binary_dictionary_test.cpp
+    ${TEST_SRC_ROOT}/binary_parity_test.cpp
     ${TEST_SRC_ROOT}/filtered_ids_test.cpp
 )
 

--- a/slugkit/tests/binary_dictionary_test.cpp
+++ b/slugkit/tests/binary_dictionary_test.cpp
@@ -22,7 +22,9 @@ namespace {
 
 constexpr IndexType kTestWordCount{7238};
 
-constexpr char kHeaderRawData[] =
+// alignas(4): the parser requires 4-byte-aligned section bases (CheckPointer); a bare
+// char[] has alignment 1, so without this the standalone-blob tests can fault on layout.
+alignas(4) constexpr char kHeaderRawData[] =
     "SLUGDICT"
     "\x02\0\0\0"             // binary format version, 2 (little-endian 4 bytes)
     "\x00\0"                 // kind markup, start 0 (little-endian 2 bytes)
@@ -39,7 +41,7 @@ constexpr char kHeaderRawData[] =
 const std::span<const std::byte> kHeaderData =
     std::span<const std::byte>(reinterpret_cast<const std::byte*>(kHeaderRawData), sizeof(kHeaderRawData));
 
-constexpr char kWordEntryRawData[] =
+alignas(4) constexpr char kWordEntryRawData[] =
     "WORDS==="
     "\0\0"    // lowercase markup, start 0 (little-endian 2 bytes)
     "\x04\0"  // lowercase markup, length 4 (little-endian 2 bytes)
@@ -57,7 +59,7 @@ const std::span<const std::byte> kWordEntryData =
 
 // A complete word data section: magic + size + count + one 24-byte word entry. (Unlike
 // kWordEntryRawData above, this includes the WordData header fields so WordData::At works.)
-constexpr char kWordDataRawData[] =
+alignas(4) constexpr char kWordDataRawData[] =
     "WORDS==="
     "\x18\0\0\0"  // size: 24-byte word-data region (little-endian 4 bytes)
     "\x01\0\0\0"  // count: 1 word (little-endian 4 bytes)

--- a/slugkit/tests/binary_parity_test.cpp
+++ b/slugkit/tests/binary_parity_test.cpp
@@ -1,0 +1,114 @@
+// Generation parity: a PatternGenerator fed a binary (memory-mapped) dictionary set must
+// produce byte-identical slugs to one fed the equivalent in-memory dictionary set. The
+// binary set is decompiled into an in-memory set so both carry identical data, then the two
+// generators are compared across selector shapes, cases, seeds and sequence numbers.
+#include <slugkit/generator/binary_dictionary.hpp>
+#include <slugkit/generator/dictionary.hpp>
+#include <slugkit/generator/pattern.hpp>
+#include <slugkit/generator/pattern_generator.hpp>
+
+#include <slugkit/test_utils/test_dictionary.hpp>
+#include <slugkit/test_utils/data_config.hpp>
+
+#include <slugkit/utils/memory_mapped_file.hpp>
+
+#include <userver/utest/utest.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace slugkit::generator {
+
+namespace {
+
+// Decompile a BinaryDictionary into one in-memory Dictionary per language, carrying the same
+// words and per-word tags, so an in-memory DictionarySet can be built from identical data.
+auto BuildInMemorySet(const binary::BinaryDictionary& dict) -> DictionarySet {
+    const std::string kind{dict.Kind()};
+
+    std::map<std::uint32_t, WordTags> word_tags;
+    for (const auto& tag_view : dict.Tags()) {
+        Tag tag{std::string{tag_view.GetUnderlying()}};
+        const auto& entry = dict[tag_view];
+        for (auto it = entry.begin(); it != entry.end(); ++it) {
+            word_tags[it->GetUnderlying()].insert(tag);
+        }
+    }
+
+    std::vector<Dictionary> dictionaries;
+    for (const auto& lang : dict.Languages()) {
+        const auto& info = dict[lang];
+        const auto start = info.FullRange().front().GetUnderlying();
+        const auto count = info.Count().GetUnderlying();
+        std::vector<Word> words;
+        words.reserve(count);
+        for (std::uint32_t i = start; i < start + count; ++i) {
+            Word w;
+            w.word = std::string{dict[IndexType(i)].Lowercase()};
+            auto f = word_tags.find(i);
+            if (f != word_tags.end()) {
+                w.tags = f->second;
+            }
+            words.push_back(std::move(w));
+        }
+        dictionaries.emplace_back(kind, lang, std::move(words));
+    }
+    return DictionarySet{std::move(dictionaries)};
+}
+
+// The case of a selector is derived from the kind's letter casing (Selector::GetCase):
+// lower=adverb, upper=ADVERB, title=Adverb, mixed=AdVerb.
+const std::vector<std::string> kPatterns = {
+    "{adverb}",
+    "{adverb@en}",
+    "{adverb@fr}",
+    "{adverb:<10}",
+    "{adverb@en:<8}",
+    "{adverb:>=12}",
+    "{adverb:+det}",
+    "{adverb:+det-nsfw}",
+    "{adverb@en:+obj}",
+    "{adverb:+det-nsfw<10}",
+    "{adverb@fr:+neut>=9}",
+    "{ADVERB}",
+    "{ADVERB@en:+obj}",
+    "{Adverb}",
+    "{Adverb@fr:<11}",
+    "{AdVerb}",
+    "{adverb}-{adverb@fr}-{number:3d}",
+    "{Adverb@en:+det}_{adverb@fr}~{special:2}",
+};
+
+void TestSlugParity(std::span<const std::byte> data, std::shared_ptr<void> keepalive) {
+    binary::BinaryDictionary dict(data);
+    auto mem = BuildInMemorySet(dict);
+
+    binary::DictionarySet bin;
+    bin.Add(data, std::move(keepalive));
+
+    for (const auto& pattern_str : kPatterns) {
+        auto pattern = std::make_shared<Pattern>(pattern_str);
+        PatternGenerator mem_gen(mem, pattern);
+        PatternGenerator bin_gen(bin, pattern);
+        for (std::uint32_t seed = 1; seed <= 8; ++seed) {
+            for (std::size_t seq = 0; seq < 64; ++seq) {
+                EXPECT_EQ(mem_gen(seed, seq), bin_gen(seed, seq))
+                    << "pattern '" << pattern_str << "' seed=" << seed << " seq=" << seq;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+UTEST(BinaryParity, InMemorySlugParity) {
+    TestSlugParity(test::kDictionaryTestData, nullptr);
+}
+
+UTEST(BinaryParity, FileSlugParity) {
+    auto file = std::make_shared<utils::MemoryMappedFile>(test::kTestDictionaryFile);
+    TestSlugParity(file->data(), file);
+}
+
+}  // namespace slugkit::generator

--- a/slugkit/tests/binary_parity_test.cpp
+++ b/slugkit/tests/binary_parity_test.cpp
@@ -4,6 +4,7 @@
 // generators are compared across selector shapes, cases, seeds and sequence numbers.
 #include <slugkit/generator/binary_dictionary.hpp>
 #include <slugkit/generator/dictionary.hpp>
+#include <slugkit/generator/generator.hpp>
 #include <slugkit/generator/pattern.hpp>
 #include <slugkit/generator/pattern_generator.hpp>
 
@@ -100,6 +101,25 @@ void TestSlugParity(std::span<const std::byte> data, std::shared_ptr<void> keepa
     }
 }
 
+// The top-level Generator (which dispatches over an in-memory / binary dictionary-set
+// variant) must likewise produce identical slugs through its batch callback API.
+void TestGeneratorParity(std::span<const std::byte> data, std::shared_ptr<void> keepalive) {
+    binary::BinaryDictionary dict(data);
+    Generator mem_gen(BuildInMemorySet(dict));
+
+    binary::DictionarySet bin_set;
+    bin_set.Add(data, std::move(keepalive));
+    Generator bin_gen(std::move(bin_set));
+
+    for (const auto& pattern_str : kPatterns) {
+        std::vector<std::string> mem_out;
+        std::vector<std::string> bin_out;
+        mem_gen.Generate(pattern_str, "parity-seed", 0, 32, [&](std::string s) { mem_out.push_back(std::move(s)); });
+        bin_gen.Generate(pattern_str, "parity-seed", 0, 32, [&](std::string s) { bin_out.push_back(std::move(s)); });
+        EXPECT_EQ(mem_out, bin_out) << "pattern '" << pattern_str << "'";
+    }
+}
+
 }  // namespace
 
 UTEST(BinaryParity, InMemorySlugParity) {
@@ -109,6 +129,10 @@ UTEST(BinaryParity, InMemorySlugParity) {
 UTEST(BinaryParity, FileSlugParity) {
     auto file = std::make_shared<utils::MemoryMappedFile>(test::kTestDictionaryFile);
     TestSlugParity(file->data(), file);
+}
+
+UTEST(BinaryParity, GeneratorSlugParity) {
+    TestGeneratorParity(test::kDictionaryTestData, nullptr);
 }
 
 }  // namespace slugkit::generator


### PR DESCRIPTION
Wires the binary memory-mapped dictionaries into the generation hot path, so the gen service can generate from mmap'd `.bin` files instead of the database with **byte-identical** output. Phase 1 of replacing the gen service's PostgreSQL dictionaries with file-based binary dictionaries (builds on #13).

## Changes

- **`binary::FilteredDictionary`** carries the selector case and the max filtered word length (computed once at filter time) — the contract the in-memory path uses for the mixed-case mask and the pattern max-length estimate.
- **`binary::DictionarySet`** keys `BinaryDictionary` by kind and dispatches `Filter(selector)`; mirrors the in-memory set's language defaulting (no language → `en`) and empty-on-miss behaviour, and retains a keepalive per dictionary so the mapped bytes outlive the views.
- **`BinarySelectorSubstitutionGenerator`** consumes `binary::WordEntry` precomputed case variants (string-views) instead of converting case per word; `kMixed` uses the lowercase variant plus a per-word mask, identical to the in-memory generator.
- **`PatternGenerator`** gains `binary::DictionarySet` constructors; its settings/init logic is templated over the dictionary-set type since the binary dictionaries reproduce the in-memory lexicographic order.
- **`binary_parity_test`**: a `PatternGenerator` fed the binary set produces byte-identical slugs to one fed the equivalent in-memory set (decompiled from the same data) across selector shapes, cases, seeds and sequence numbers, for both the embedded and memory-mapped fixtures.
- Align the standalone test blobs to 4 bytes (the parser requires aligned section bases).

## Validation

Full suite **159/159 pass** (clang-18), including both new `BinaryParity` slug-parity tests.

## Follow-up (not in this PR)

The compiler precomputes upper/title via Python `.upper()`/`.title()`, while the in-memory runtime uses ICU `ToUpper`/`Capitalize`. ASCII single words match (parity passes on the adverb fixture), but multi-word/non-ASCII entries could diverge for title/upper — to be aligned before a production cutover. The `Generator` wrapper + gen-service wiring (`dictionary-source: db|files`, `.bin` packaging) are the next phase.