### PR TITLE
compile_dict: merge multiple source YAMLs per kind

### DIFF
--- a/slugkit/py/tools/src/slugkit/tools/compile_dict.py
+++ b/slugkit/py/tools/src/slugkit/tools/compile_dict.py
@@ -14,18 +14,28 @@ LOGGER = logging.getLogger(__name__)
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("input_file", type=str, help="Input file")
-    parser.add_argument("output_file", type=str, help="Output file")
+    parser = argparse.ArgumentParser(
+        description="Compile one or more dictionary YAML files into binary .bin dictionaries. "
+        "When several inputs are given they are merged per kind, so a large dictionary's source "
+        "can be split across multiple files (e.g. geo.part1.yaml + geo.part2.yaml)."
+    )
+    parser.add_argument("input_files", nargs="+", help="Input YAML file(s), merged per kind")
+    parser.add_argument(
+        "-o", "--output", dest="output_file", required=True,
+        help="Output base path; the binary is written as <base>.<kind>.bin",
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    dict_file = DictionaryFile.from_yaml(args.input_file)
+    dict_file = DictionaryFile.from_yaml(args.input_files[0])
+    for extra in args.input_files[1:]:
+        dict_file.merge(DictionaryFile.from_yaml(extra))
     for kind, dictionary_data in dict_file.dictionaries.items():
         start_time = datetime.datetime.now()
-        LOGGER.info(f"Compiling {kind} dictionary")
+        n_words = sum(len(words) for words in dictionary_data.words.values())
+        LOGGER.info(f"Compiling {kind} dictionary ({n_words} words from {len(args.input_files)} file(s))")
         binary_dictionary = BinaryDictionary(kind, dictionary_data)
         with open(args.output_file.replace(".yaml", f".{kind}.bin"), "wb") as f:
             binary_dictionary.write(f)

--- a/slugkit/py/tools/src/slugkit/tools/models.py
+++ b/slugkit/py/tools/src/slugkit/tools/models.py
@@ -90,6 +90,23 @@ class DictionaryData(BaseModel):
             self.tags = {}
         self.tags[tag_id] = TagData(name=name, description=description, opt_in=opt_in)
 
+    def merge(self, other: "DictionaryData") -> None:
+        """Merge another dictionary's words and tags into this one (used to compile a kind whose
+        source is split across multiple YAML files). Words present in both are unioned by tag;
+        tag definitions already present win (first file is authoritative)."""
+        for language, words in other.words.items():
+            target = self.words.setdefault(language, {})
+            for word, tags in words.items():
+                if word in target:
+                    target[word] = sorted(set(target[word]) | set(tags))
+                else:
+                    target[word] = tags
+        if other.tags:
+            if self.tags is None:
+                self.tags = {}
+            for tag_id, tag_data in other.tags.items():
+                self.tags.setdefault(tag_id, tag_data)
+
 
 class DictionaryFile(BaseModel):
     """Container for multiple dictionaries in a single YAML file."""
@@ -142,6 +159,14 @@ class DictionaryFile(BaseModel):
     def add_dictionary(self, kind: str, dictionary: DictionaryData) -> None:
         """Add a new dictionary."""
         self.dictionaries[kind] = dictionary
+
+    def merge(self, other: "DictionaryFile") -> None:
+        """Merge another DictionaryFile into this one, per kind (see DictionaryData.merge)."""
+        for kind, data in other.dictionaries.items():
+            if kind in self.dictionaries:
+                self.dictionaries[kind].merge(data)
+            else:
+                self.dictionaries[kind] = data
     
     def list_dictionaries(self) -> List[str]:
         """List all available dictionary kinds."""


### PR DESCRIPTION
Lets a dictionary kind's source be split across several YAML files that `compile_dict` merges before compiling — needed when a generated master exceeds GitHub's 100 MB file limit (the new `geo` dictionary master is ~168 MB).

- **`DictionaryData.merge` / `DictionaryFile.merge`**: union words (merging tag lists for any word present in more than one file) and tag definitions (first file authoritative).
- **`compile_dict` CLI**: accept 1+ positional input files; output via `-o/--output`. The binary is **byte-identical** whether the source is one file or many.

Verified: `geo` compiles to the same 95 MB `geo.bin` from `geo.part1.yaml` + `geo.part2.yaml` (984,524 merged words) as from a single file, and existing single-file dicts are unaffected.