### PR TITLE
Fix O(n^2) FilteredDictionary max-length (binary path) + bin-dict CLI

### DIFF
--- a/slugkit/examples/CMakeLists.txt
+++ b/slugkit/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(yaml-dict)
+add_subdirectory(bin-dict)

--- a/slugkit/examples/bin-dict/CMakeLists.txt
+++ b/slugkit/examples/bin-dict/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(bin-dict main.cpp)
+
+target_link_libraries(bin-dict
+    PRIVATE
+        Boost::program_options
+        slugkit-generator
+)
+target_include_directories(bin-dict PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/slugkit/examples/bin-dict/main.cpp
+++ b/slugkit/examples/bin-dict/main.cpp
@@ -1,0 +1,97 @@
+#include <slugkit/generator/binary_dictionary.hpp>
+#include <slugkit/generator/generator.hpp>
+
+#include <userver/engine/run_standalone.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <fmt/format.h>
+
+// CLI for generating from compiled binary (.bin) dictionaries -- the same code path the gen
+// service uses with dictionary-source: files. Lets us reproduce / verify binary-path behaviour
+// and timing (e.g. heavy tag filters over large dictionaries) locally before deploying.
+
+namespace {
+
+std::shared_ptr<std::vector<std::byte>> ReadFile(const std::string& path) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+        throw std::runtime_error(fmt::format("Failed to open file: {}", path));
+    }
+    const auto size = static_cast<std::size_t>(file.tellg());
+    file.seekg(0);
+    auto buffer = std::make_shared<std::vector<std::byte>>(size);
+    file.read(reinterpret_cast<char*>(buffer->data()), static_cast<std::streamsize>(size));
+    return buffer;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) try {
+    namespace po = boost::program_options;
+    po::options_description desc("Binary Dictionary Generator");
+    // clang-format off
+    desc.add_options()
+        ("help,h", "produce help message")
+        ("bin,b", po::value<std::vector<std::string>>()->required()->multitoken(),
+            "one or more compiled .bin dictionary files to load")
+        ("pattern,p", po::value<std::string>()->required(), "pattern to use")
+        ("count,c", po::value<std::size_t>()->default_value(1), "number of slugs to generate")
+        ("sequence,n", po::value<std::size_t>()->default_value(0), "sequence number")
+        ("seed,s", po::value<std::string>(), "seed for the generator (random if omitted)")
+    ;
+    // clang-format on
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return 0;
+    }
+    po::notify(vm);
+
+    auto bin_files = vm["bin"].as<std::vector<std::string>>();
+    auto pattern = vm["pattern"].as<std::string>();
+    auto sequence = vm["sequence"].as<std::size_t>();
+    auto count = vm["count"].as<std::size_t>();
+
+    // The generator uses userver synchronisation primitives, so build and run it inside a
+    // standalone coroutine context.
+    userver::engine::RunStandalone([&] {
+        slugkit::generator::binary::DictionarySet dictionaries;
+        for (const auto& path : bin_files) {
+            auto buffer = ReadFile(path);
+            std::span<const std::byte> data{buffer->data(), buffer->size()};
+            dictionaries.Add(data, buffer);  // buffer kept alive by the DictionarySet
+            std::cerr << fmt::format("Loaded {} ({} bytes)\n", path, buffer->size());
+        }
+        slugkit::generator::Generator generator(std::move(dictionaries));
+        std::string seed = vm.count("seed") ? vm["seed"].as<std::string>() : generator.RandomSeed();
+
+        auto pattern_ptr = std::make_shared<slugkit::generator::Pattern>(pattern);
+        std::cerr << fmt::format("Pattern: {}\nComplexity: {}\nSeed: {}\n---\n", pattern,
+                                 pattern_ptr->Complexity(), seed);
+
+        const auto start = std::chrono::steady_clock::now();
+        if (count == 1) {
+            std::cout << generator(pattern_ptr, seed, sequence) << '\n';
+        } else {
+            generator(pattern_ptr, seed, sequence, count,
+                      [](const std::string& slug) { std::cout << slug << '\n'; });
+        }
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        const auto ms = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count() / 1000.0;
+        std::cerr << fmt::format("---\nGenerated {} slug(s) in {:.3f} ms ({:.3f} ms/slug)\n",
+                                 count, ms, ms / static_cast<double>(count));
+    });
+
+} catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+}

--- a/slugkit/include/slugkit/generator/filter/filtered_ids.hpp
+++ b/slugkit/include/slugkit/generator/filter/filtered_ids.hpp
@@ -126,6 +126,15 @@ public:
         return begin_ <= index && index < end_;
     }
 
+    /// @brief Visit every logical index in the range in ascending order. O(count), no per-index
+    /// position lookup (unlike at()).
+    template <typename F>
+    void for_each(F&& f) const {
+        for (auto i = begin_.GetUnderlying(); i < end_.GetUnderlying(); ++i) {
+            f(IndexType(i));
+        }
+    }
+
     /// @brief Intersection of two index ranges.
     auto operator*(const IndexRange& other) const noexcept -> IndexRange {
         if (!(*this & other)) {
@@ -231,6 +240,15 @@ public:
 
     //{@
     /// @name Range iteration
+    /// @brief Visit every logical index across all ranges in ascending order. O(count) total,
+    /// without the per-index O(ranges) at() lookup.
+    template <typename F>
+    void for_each(F&& f) const {
+        for (const auto& range : ranges_) {
+            range.for_each(f);
+        }
+    }
+
     auto begin() const noexcept -> range_iterator_type {
         return ranges_.begin();
     }
@@ -370,6 +388,14 @@ public:
 
     [[nodiscard]] auto count() const noexcept -> IndexType {
         return IndexType(size());
+    }
+
+    /// @brief Visit every index in the set in ascending order.
+    template <typename F>
+    void for_each(F&& f) const {
+        for (const auto& index : indexes_) {
+            f(index);
+        }
     }
 
     [[nodiscard]] auto density() const -> float {
@@ -550,6 +576,14 @@ public:
         return begin_[index.GetUnderlying()];
     }
 
+    /// @brief Visit every index in the view in ascending order.
+    template <typename F>
+    void for_each(F&& f) const {
+        for (auto it = begin_; it != end_; ++it) {
+            f(*it);
+        }
+    }
+
     auto at(IndexType::UnderlyingType index) const -> IndexType {
         return begin_[index];
     }
@@ -702,6 +736,12 @@ public:
 
     auto at(IndexType::UnderlyingType index) const -> IndexType {
         return at(IndexType(index));
+    }
+
+    /// @brief Visit every logical index in ascending order in O(count) (no per-index at()).
+    template <typename F>
+    void for_each(F&& f) const {
+        std::visit([&f](const auto& chunk) { chunk.for_each(f); }, chunk_);
     }
 
     auto front() const noexcept -> IndexType {

--- a/slugkit/src/slugkit/generator/binary_dictionary.cpp
+++ b/slugkit/src/slugkit/generator/binary_dictionary.cpp
@@ -553,12 +553,14 @@ auto FilteredDictionary::operator[](IndexType index) const -> const WordEntry& {
 
 auto FilteredDictionary::ComputeMaxLength() const -> std::size_t {
     // Max byte length over the filtered words, matching the in-memory FilteredDictionary.
+    // Visit logical indices directly (O(count)); the old per-position indices_.at(i) was an
+    // O(ranges) scan, making this O(count * ranges) -- ~25s for a scattered exclude over a 1M-word
+    // dictionary (e.g. {geo:-multi_token}).
     std::size_t max_length = 0;
-    const auto count = indices_.count().GetUnderlying();
-    for (IndexType::UnderlyingType i = 0; i < count; ++i) {
-        const auto offset = (*index_table_)[indices_.at(IndexType(i))];
+    indices_.for_each([&](IndexType logical_index) {
+        const auto offset = (*index_table_)[logical_index];
         max_length = std::max(max_length, word_data_->At(offset).Lowercase().size());
-    }
+    });
     return max_length;
 }
 


### PR DESCRIPTION
## Problem
The binary (files) dictionary path recomputed `FilteredDictionary::max_length` on **every** generation request by looping over all filtered words calling `IndexRangeSequence::at(i)` — a linear O(ranges) scan — making it **O(count × ranges)**. A scattered exclude over a ~1M-word dictionary (`{geo:-multi_token}`: ~14k ranges over ~970k words) took **~25 s per request**, saturating the gen service.

## Fix
Visit logical indices directly via a new `for_each` on each filter chunk (`IndexRange` / `IndexRangeSequence` / `IndexSet` / `IndexSetView`) → **O(count)**. Output is **byte-identical** (`max_length` feeds capacity via `1<<maxlen`, so this had to be exact).

Verified on the geo dictionary via the new CLI:
- `{geo:-multi_token}` ×5: **5568 ms → 3.5 ms** (~1580×), identical slugs.
- `{geo:-multi_token}` ×2000: 34 ms; unfiltered / include filters unaffected.

## Also
`examples/bin-dict` — a CLI that loads compiled `.bin` dictionaries and times generation (the same path the gen service uses with `dictionary-source: files`), so binary-path behaviour/timing can be reproduced locally before deploying.

## Follow-ups (separate)
Binary-path `FilteredDictionary` cache (avoid per-request rebuilds under load), O(log) `IndexRangeSequence::at()` for very large counts, and baking per-tag max length into the format.