### PR TITLE
binary dict: cache filtered dictionaries per selector

### DIFF
--- a/slugkit/include/slugkit/generator/binary_dictionary.hpp
+++ b/slugkit/include/slugkit/generator/binary_dictionary.hpp
@@ -4,8 +4,11 @@
 #include <slugkit/generator/dictionary_types.hpp>
 #include <slugkit/generator/pattern.hpp>
 
+#include <userver/cache/nway_lru_cache.hpp>
+
 #include <fmt/format.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -116,12 +119,21 @@ private:
     auto Validate() const -> void;
 
 private:
+    // Per-selector cache of built filtered dictionaries, keyed by Selector::GetHash(). The binary
+    // Filter path otherwise rebuilds the whole FilteredDictionary every request; this mirrors the
+    // in-memory path's FilteredDictionaryCache (userver thread-safe sharded LRU). Held by
+    // shared_ptr so BinaryDictionary stays movable (it's stored by value in DictionarySet).
+    using FilterCache = userver::cache::NWayLRU<std::int64_t, FilteredDictionaryPtr>;
+    static constexpr std::size_t kFilterCacheWays = 16UL;
+    static constexpr std::size_t kFilterCacheWaySize = 1024UL;
+
     RawData data_;
     const detail::Header* header_;
     const detail::IndexTable* index_table_;
     const detail::LanguageTable* language_table_;
     const detail::TagsTable* tags_table_;
     const detail::WordData* word_data_;
+    std::shared_ptr<FilterCache> filter_cache_;
 };
 
 /// @brief A set of binary dictionaries keyed by kind, the binary counterpart of

--- a/slugkit/src/slugkit/generator/binary_dictionary.cpp
+++ b/slugkit/src/slugkit/generator/binary_dictionary.cpp
@@ -582,6 +582,7 @@ BinaryDictionary::BinaryDictionary(RawData data)
     consumed_size += detail::Align(tags_table_->Size()).GetUnderlying();
 
     word_data_ = detail::WordData::GetWordData(data_.subspan(consumed_size));
+    filter_cache_ = std::make_shared<FilterCache>(kFilterCacheWays, kFilterCacheWaySize);
 
     Validate();
 }
@@ -616,10 +617,19 @@ auto BinaryDictionary::operator[](IndexType index) const -> const WordEntry& {
 }
 
 auto BinaryDictionary::Filter(const Selector& selector) const -> FilteredDictionaryPtr {
+    // Reuse the built filtered dictionary for identical selectors (same language/tags/size/case);
+    // building it (filter + max-length) is the expensive part, so caching keeps repeated patterns
+    // cheap under load. Keyed by the selector's identity hash, same as the in-memory path.
+    const auto hash = selector.GetHash();
+    if (auto cached = filter_cache_->Get(hash)) {
+        return *cached;
+    }
     auto index_sequence = language_table_->Filter(selector.language, selector.size_limit);
     auto indices = tags_table_->Filter(index_sequence, selector.include_tags, selector.exclude_tags);
     // TODO opt-in tags
-    return std::make_shared<FilteredDictionary>(indices, index_table_, word_data_, selector.GetCase());
+    auto filtered = std::make_shared<FilteredDictionary>(indices, index_table_, word_data_, selector.GetCase());
+    filter_cache_->Put(hash, filtered);
+    return filtered;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds the per-selector `FilteredDictionary` cache the in-memory path already has, to the binary (files) path — a per-`BinaryDictionary` userver `NWayLRU` keyed by `Selector::GetHash()` (thread-safe, bounded 16×1024, held by `shared_ptr` so the dictionary stays movable). Repeated patterns reuse the built filtered dictionary instead of rebuilding it (filter + max-length) every request. Byte-identical output; verified a repeated selector hits the cache. Builds on #18.