### PR TITLE
generator: cross-compile toolchains for the mobile C ABI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 # python stuff
 __pycache__*
 
+# CMake build trees
+build/
+

--- a/cmake/toolchains/android.cmake
+++ b/cmake/toolchains/android.cmake
@@ -1,0 +1,36 @@
+# Android (NDK) toolchain wrapper for the slugkit generator.
+# Resolves the NDK location, then chains to the NDK's own android.toolchain.cmake.
+#
+# Usage:
+#   export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/<version>
+#   cmake -S slugkit/mobile -B build/android-arm64 \
+#         -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/android.cmake \
+#         -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-24
+#
+# ANDROID_ABI: arm64-v8a | armeabi-v7a | x86_64 | x86  (default arm64-v8a)
+
+if(NOT ANDROID_NDK)
+    foreach(_var ANDROID_NDK_HOME ANDROID_NDK_ROOT NDK_ROOT)
+        if(DEFINED ENV{${_var}} AND EXISTS "$ENV{${_var}}")
+            set(ANDROID_NDK "$ENV{${_var}}")
+            break()
+        endif()
+    endforeach()
+endif()
+
+if(NOT ANDROID_NDK OR NOT EXISTS "${ANDROID_NDK}")
+    message(FATAL_ERROR
+        "Android NDK not found. Set ANDROID_NDK_HOME (or pass -DANDROID_NDK=/path/to/ndk).")
+endif()
+
+if(NOT ANDROID_ABI)
+    set(ANDROID_ABI "arm64-v8a")
+endif()
+if(NOT ANDROID_PLATFORM)
+    set(ANDROID_PLATFORM "android-24")
+endif()
+
+# Modern C++/STL and static libc++ so the .so is self-contained.
+set(ANDROID_STL "c++_static")
+
+include("${ANDROID_NDK}/build/cmake/android.toolchain.cmake")

--- a/cmake/toolchains/ios-device.cmake
+++ b/cmake/toolchains/ios-device.cmake
@@ -1,0 +1,15 @@
+# iOS device (arm64) toolchain for the slugkit generator.
+# Usage: cmake -S slugkit/mobile -B build/ios -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ios-device.cmake
+# Relies on CMake's built-in iOS support (>= 3.14) driving the Xcode iPhoneOS SDK.
+
+set(CMAKE_SYSTEM_NAME iOS)
+set(CMAKE_OSX_SYSROOT iphoneos CACHE STRING "iOS device SDK")
+set(CMAKE_OSX_ARCHITECTURES arm64 CACHE STRING "iOS device architecture")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum iOS version")
+
+# Static library output; no code signing needed for a library artifact.
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)

--- a/cmake/toolchains/ios-simulator.cmake
+++ b/cmake/toolchains/ios-simulator.cmake
@@ -1,0 +1,13 @@
+# iOS simulator (arm64 + x86_64) toolchain for the slugkit generator.
+# Usage: cmake -S slugkit/mobile -B build/ios-sim -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ios-simulator.cmake
+
+set(CMAKE_SYSTEM_NAME iOS)
+set(CMAKE_OSX_SYSROOT iphonesimulator CACHE STRING "iOS simulator SDK")
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "iOS simulator architectures")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum iOS version")
+
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)

--- a/mobile-ffi-proposal.md
+++ b/mobile-ffi-proposal.md
@@ -377,11 +377,45 @@ A C ABI now wraps the engine and is verified end-to-end on host.
   variant matches alloc variant, buffer-too-small reports required length, batch of 5,
   and a malformed pattern returns NULL without crashing. All checks pass.
 
-### What remains
+### What remains (after Phase 3)
 - **Serialisation layer** (`generator/io/`, `structured_loader.hpp`,
   `string_view_serialize.hpp`, `numeric.hpp` I/O) is still userver-only and excluded —
   needs a userver-free YAML/JSON path (or buffer-only dict construction) for mobile.
 - **Verify the userver build** of the CMake flag changes in the devcontainer.
-- **Cross-toolchains** (NDK / iOS / wasm) and **per-language bindings**
-  (Swift XCFramework, Kotlin AAR, Dart ffi plugin) per Phases 4–6 above. The C ABI
-  is the substrate they all bind to.
+
+## Phase 4 results — cross toolchains
+
+The C ABI now cross-compiles to every target. A dependency-self-contained build
+(`slugkit/mobile/CMakeLists.txt`) fetches **fmt** (11.1.4) and **utf8proc** (2.9.0)
+from source so they get the correct target ABI; boost is header-only (a host
+checkout is found via `NO_CMAKE_FIND_ROOT_PATH`, since header-only boost is
+host-independent). Toolchain files live in `cmake/toolchains/`; `CMakePresets.json`
+ties the targets together.
+
+**Verified builds (compilation is the proof; no device/emulator needed):**
+
+| Target | Toolchain | Artefact | Result |
+|---|---|---|---|
+| Host (macOS arm64) | native | `libslugkit_c.a` | ✅ golden 9/9 + C ABI test pass |
+| iOS device | `ios-device.cmake` (SYSROOT iphoneos) | `libslugkit_c.a` (arm64) | ✅ |
+| iOS simulator | `ios-simulator.cmake` | `libslugkit_c.a` (arm64 + x86_64 fat) | ✅ |
+| Android arm64-v8a | NDK 28 via `android.cmake` | `libslugkit_c.so` (aarch64) | ✅ 10 `slk_*` symbols exported |
+| WebAssembly | emscripten (`emcmake`) | `libslugkit_c.a` (wasm) | ✅ |
+
+**Notes / fixes surfaced by cross-compiling:**
+- **fmt** ≥ 11.1.4 is required for emscripten (11.0.2 fails its own `consteval`
+  format-string checks under emscripten's clang).
+- **Portability fix in `placeholders.cpp`** (emoji option parsing): three
+  `std::string_view(iterator, size)` constructions were only valid because macOS /
+  NDK libc++ expose `string_view` iterators as raw pointers; emscripten's libc++
+  wraps them. Switched to `.data()`-based construction — behaviour-identical, and the
+  host golden/C-ABI tests still pass byte-for-byte.
+- Android builds a shared `.so` (`SLUGKIT_MOBILE_SHARED=ON`, `c++_static` STL) with
+  C ABI symbols kept visible; iOS/host/wasm build static archives.
+
+### What remains (after Phase 4)
+- **Per-language binding packages**: Swift XCFramework (bundle device + simulator
+  slices + module map), Kotlin/Android AAR (JNI wrapper over the `.so`s), Dart/Flutter
+  ffi plugin. The C ABI is the substrate they all bind to.
+- **Verify the userver build** of the earlier CMake flag changes in the devcontainer.
+- Userver-free serialisation/YAML path; on-device dictionary loading from app assets.

--- a/slugkit/mobile/CMakeLists.txt
+++ b/slugkit/mobile/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.24)
+project(slugkit-mobile CXX C)
+
+# Cross-compilable, userver-free build of the generator core + the slugkit_c C ABI, packaged as a
+# library for mobile/embedded targets (iOS, Android, wasm, host). Select a target by passing a
+# toolchain / preset (see cmake/toolchains and CMakePresets.json at the generator root).
+#
+# Dependencies are made self-contained so the build works on any target:
+#   - fmt and utf8proc are fetched and compiled from source (correct target ABI);
+#   - boost is header-only here (after dropping boost::locale/ICU), so only an include dir is needed.
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Build a shared library (e.g. Android .so) instead of a static archive.
+option(SLUGKIT_MOBILE_SHARED "Build slugkit_c as a shared library" OFF)
+
+get_filename_component(SLUGKIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+
+# --- Boost (header-only) -------------------------------------------------------------------------
+# Point at any Boost include tree; header-only components (multiprecision, functional/hash,
+# algorithm, range) are platform-independent, so a host Boost checkout is fine for cross builds.
+set(SLUGKIT_BOOST_INCLUDE_DIR "" CACHE PATH "Path to Boost headers (contains boost/)")
+if(NOT SLUGKIT_BOOST_INCLUDE_DIR)
+    # Separate find variable: find_path no-ops if its result var is already a set cache entry.
+    # NO_CMAKE_FIND_ROOT_PATH: boost here is header-only and host-independent, so allow finding a
+    # host boost checkout even when a cross toolchain (Android/iOS/wasm) restricts finds to its sysroot.
+    find_path(SLUGKIT_BOOST_INCLUDE_DIR_FOUND boost/multiprecision/cpp_int.hpp
+        HINTS
+            /opt/homebrew/include
+            /usr/local/include
+            /usr/include
+        NO_CMAKE_FIND_ROOT_PATH)
+    if(SLUGKIT_BOOST_INCLUDE_DIR_FOUND)
+        set(SLUGKIT_BOOST_INCLUDE_DIR "${SLUGKIT_BOOST_INCLUDE_DIR_FOUND}")
+    endif()
+endif()
+if(NOT SLUGKIT_BOOST_INCLUDE_DIR)
+    message(FATAL_ERROR "Boost headers not found; set -DSLUGKIT_BOOST_INCLUDE_DIR=/path/to/boost/include")
+endif()
+message(STATUS "slugkit-mobile: Boost headers at ${SLUGKIT_BOOST_INCLUDE_DIR}")
+
+# --- fmt + utf8proc (compiled from source for the target) ----------------------------------------
+include(FetchContent)
+
+set(FMT_INSTALL OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 11.1.4
+    GIT_SHALLOW TRUE)
+
+FetchContent_Declare(utf8proc
+    GIT_REPOSITORY https://github.com/JuliaStrings/utf8proc.git
+    GIT_TAG v2.9.0
+    GIT_SHALLOW TRUE)
+
+FetchContent_MakeAvailable(fmt utf8proc)
+
+# --- Core sources (same set as the host spike) ---------------------------------------------------
+set(CORE_SOURCES
+    ${SLUGKIT_DIR}/src/slugkit/utils/numeric.cpp
+    ${SLUGKIT_DIR}/src/slugkit/utils/roman.cpp
+    ${SLUGKIT_DIR}/src/slugkit/utils/text.cpp
+    ${SLUGKIT_DIR}/src/slugkit/utils/primes.cpp
+    ${SLUGKIT_DIR}/src/slugkit/utils/memory_mapped_file.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/permutations.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/dictionary.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/binary_dictionary.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/pattern.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/placeholders.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/pattern_generator.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/generator.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/detail/pattern_parser.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/detail/indexes.cpp
+    ${SLUGKIT_DIR}/src/slugkit/generator/filter/filtered_ids.cpp
+    ${SLUGKIT_DIR}/src/slugkit/c/slugkit_c.cpp
+)
+
+if(SLUGKIT_MOBILE_SHARED)
+    add_library(slugkit_c SHARED ${CORE_SOURCES})
+else()
+    add_library(slugkit_c STATIC ${CORE_SOURCES})
+endif()
+
+# No SLUGKIT_USE_USERVER / SLUGKIT_GENERATOR_WITH_SERIALIZATION -> standalone compat branches.
+target_include_directories(slugkit_c
+    PUBLIC
+        ${SLUGKIT_DIR}/include
+    PRIVATE
+        ${SLUGKIT_DIR}/src
+        ${SLUGKIT_BOOST_INCLUDE_DIR})
+target_link_libraries(slugkit_c PRIVATE fmt::fmt utf8proc)
+
+# Keep the C ABI symbols visible in the shared library even under -fvisibility=hidden.
+set_target_properties(slugkit_c PROPERTIES
+    C_VISIBILITY_PRESET default
+    CXX_VISIBILITY_PRESET default)

--- a/slugkit/mobile/CMakePresets.json
+++ b/slugkit/mobile/CMakePresets.json
@@ -1,0 +1,61 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 24, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "host",
+      "inherits": "base",
+      "displayName": "Host (macOS/Linux, native)",
+      "description": "Native build for local testing"
+    },
+    {
+      "name": "ios-device",
+      "inherits": "base",
+      "displayName": "iOS device (arm64)",
+      "toolchainFile": "${sourceDir}/../../cmake/toolchains/ios-device.cmake"
+    },
+    {
+      "name": "ios-simulator",
+      "inherits": "base",
+      "displayName": "iOS simulator (arm64 + x86_64)",
+      "toolchainFile": "${sourceDir}/../../cmake/toolchains/ios-simulator.cmake"
+    },
+    {
+      "name": "android-arm64",
+      "inherits": "base",
+      "displayName": "Android arm64-v8a (.so)",
+      "toolchainFile": "${sourceDir}/../../cmake/toolchains/android.cmake",
+      "cacheVariables": {
+        "ANDROID_ABI": "arm64-v8a",
+        "ANDROID_PLATFORM": "android-24",
+        "SLUGKIT_MOBILE_SHARED": "ON"
+      }
+    },
+    {
+      "name": "android-x86_64",
+      "inherits": "base",
+      "displayName": "Android x86_64 (.so)",
+      "toolchainFile": "${sourceDir}/../../cmake/toolchains/android.cmake",
+      "cacheVariables": {
+        "ANDROID_ABI": "x86_64",
+        "ANDROID_PLATFORM": "android-24",
+        "SLUGKIT_MOBILE_SHARED": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "host", "configurePreset": "host" },
+    { "name": "ios-device", "configurePreset": "ios-device" },
+    { "name": "ios-simulator", "configurePreset": "ios-simulator" },
+    { "name": "android-arm64", "configurePreset": "android-arm64" },
+    { "name": "android-x86_64", "configurePreset": "android-x86_64" }
+  ]
+}

--- a/slugkit/src/slugkit/generator/placeholders.cpp
+++ b/slugkit/src/slugkit/generator/placeholders.cpp
@@ -364,7 +364,10 @@ void EmojiGen::ApplyOptions(
             if (pos != option.second.end()) {
                 throw PatternSyntaxError(fmt::format(
                     "Unexpected character(s) after count option: {} at column {}",
-                    std::string_view(pos, option.second.end() - pos),
+                    // Build from a raw pointer + length: a string_view's iterator is a raw pointer on
+                    // some libc++ builds but a wrapped iterator on others (e.g. emscripten), so the
+                    // (iterator, size) constructor is not portable.
+                    std::string_view(option.second.data() + (pos - option.second.begin()), option.second.end() - pos),
                     pos - original_pattern.begin()
                 ));
             }
@@ -385,7 +388,7 @@ void EmojiGen::ApplyOptions(
                     option.second.begin() - original_pattern.begin()
                 ));
             }
-            count_option = std::string_view(option.first.begin(), option.second.end() - option.first.begin());
+            count_option = std::string_view(option.first.data(), option.second.end() - option.first.begin());
             has_options_ = true;
         } else if (option.first == kUniqueOption) {
             if (option.second == "true" || option.second == "yes") {
@@ -397,7 +400,7 @@ void EmojiGen::ApplyOptions(
                     option.second.begin() - original_pattern.begin()
                 ));
             }
-            unique_option = std::string_view(option.first.begin(), option.second.end() - option.first.begin());
+            unique_option = std::string_view(option.first.data(), option.second.end() - option.first.begin());
             has_options_ = true;
         } else if (option.first == kToneOption) {
             tone = option.second;


### PR DESCRIPTION
## What

Builds on the merged userver-free core + C ABI (#21) by adding a **cross-compilable build** of `slugkit_c` plus toolchains/presets, and **verifies it compiles to every mobile target**.

## How

- **`slugkit/mobile/CMakeLists.txt`** — dependency-self-contained build of the userver-free core + `slugkit_c`. **fmt** (11.1.4) and **utf8proc** (2.9.0) are fetched and compiled from source so they get the correct target ABI; **boost is header-only** (after the earlier `boost::locale`→utf8proc swap) and found via `NO_CMAKE_FIND_ROOT_PATH` since header-only boost is host-independent. Static archive by default; shared `.so` for Android (`SLUGKIT_MOBILE_SHARED=ON`).
- **`cmake/toolchains/`** — `ios-device.cmake`, `ios-simulator.cmake`, `android.cmake` (NDK wrapper resolving `ANDROID_NDK_HOME`).
- **`slugkit/mobile/CMakePresets.json`** — `host` / `ios-device` / `ios-simulator` / `android-arm64` / `android-x86_64`.

## Verified builds

Compilation is the proof (no device/emulator needed):

| Target | Artefact | Result |
|---|---|---|
| Host (macOS arm64) | `libslugkit_c.a` | ✅ golden 9/9 + C ABI test pass |
| iOS device | `libslugkit_c.a` (arm64) | ✅ |
| iOS simulator | `libslugkit_c.a` (arm64 + x86_64 fat) | ✅ |
| Android arm64-v8a | `libslugkit_c.so` (aarch64) | ✅ 10 `slk_*` symbols exported |
| WebAssembly | `libslugkit_c.a` (wasm, emscripten) | ✅ |

## Surfaced by cross-compiling

- **Portability fix in `placeholders.cpp`** (emoji option parsing): three `std::string_view(iterator, size)` constructions were only valid because macOS/NDK libc++ expose `string_view` iterators as raw pointers; emscripten's libc++ wraps them. Switched to `.data()`-based construction — **behaviour-identical**, and the host golden + C ABI tests still pass byte-for-byte.
- **fmt ≥ 11.1.4** is required for emscripten (11.0.2 fails its own `consteval` format-string checks under emscripten's clang).

## Notes

- Cross builds use a host boost checkout for headers (found automatically); no `-D` needed.
- Android/iOS/wasm SDKs were available locally for verification; the toolchains resolve NDK via `ANDROID_NDK_HOME` and iOS via the Xcode SDK.
- Next: per-language binding packages (Swift XCFramework, Kotlin AAR, Dart ffi plugin) — the C ABI is the substrate they bind to.