### PR TITLE
bindings: Swift package + XCFramework for the C ABI

### DIFF
--- a/bindings/swift/.gitignore
+++ b/bindings/swift/.gitignore
@@ -1,0 +1,7 @@
+# SwiftPM
+.build/
+.swiftpm/
+Package.resolved
+
+# Prebuilt native artifact (produced by scripts/build-xcframework.sh)
+Slugkit.xcframework/

--- a/bindings/swift/Package.swift
+++ b/bindings/swift/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// Slugkit Swift package.
+//
+// The native engine is delivered as a prebuilt XCFramework (macOS + iOS device + iOS simulator),
+// produced by scripts/build-xcframework.sh. Run that script before `swift build`/`swift test`.
+let package = Package(
+    name: "Slugkit",
+    platforms: [.macOS(.v11), .iOS(.v13)],
+    products: [
+        .library(name: "Slugkit", targets: ["Slugkit"]),
+    ],
+    targets: [
+        // Prebuilt C ABI (libslugkit_c + core) with a module map exposing slugkit_c.h as `CSlugkit`.
+        .binaryTarget(name: "CSlugkit", path: "Slugkit.xcframework"),
+        // Idiomatic Swift wrapper over the C ABI. The native lib is C++ (fmt, engine), so link libc++.
+        .target(
+            name: "Slugkit",
+            dependencies: ["CSlugkit"],
+            linkerSettings: [.linkedLibrary("c++")]
+        ),
+        .testTarget(name: "SlugkitTests", dependencies: ["Slugkit"]),
+    ]
+)

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -1,0 +1,52 @@
+# Slugkit — Swift binding
+
+Idiomatic Swift wrapper over the SlugKit generator engine's C ABI (`slugkit_c`),
+distributed as a Swift package backed by a prebuilt **XCFramework** (macOS + iOS
+device + iOS simulator).
+
+## Build
+
+The native engine is delivered as `Slugkit.xcframework`, produced from the
+userver-free C ABI by a script (it is a build artefact and is git-ignored):
+
+```sh
+cd bindings/swift
+./scripts/build-xcframework.sh   # builds macOS + iOS device + iOS simulator slices
+swift build
+swift test
+```
+
+The script cross-compiles the core + `slugkit_c` for each Apple platform via the
+CMake presets/toolchains, merges the fmt/utf8proc archives into a self-contained
+static library per slice, and assembles the XCFramework.
+
+## Usage
+
+```swift
+import Slugkit
+
+// Load one or more compiled binary dictionaries (.bin).
+let dict = try Data(contentsOf: emojiBinURL)
+let generator = try Generator(binaryDictionary: dict)
+
+let slug = try generator.generate("{emoji}", seed: "foobar", sequence: 0)
+
+// Capacity (arbitrary precision, returned as a decimal string).
+let cap = try generator.capacity(of: "{emoji}")   // cap.value, cap.maxLength
+
+// Batch generation (no per-slug allocation on the native side).
+try generator.generate("{adjective}-{noun}", seed: "s", sequence: 0, count: 100) { slug in
+    print(slug)
+}
+```
+
+`Generator` is thread-safe for concurrent generation; construct once and reuse.
+Generation is deterministic: the same `(pattern, seed, sequence)` always yields
+the same slug.
+
+## Layout
+
+- `Package.swift` — SwiftPM manifest (binary `CSlugkit` target + `Slugkit` wrapper).
+- `Sources/Slugkit/Slugkit.swift` — the public Swift API.
+- `Tests/SlugkitTests/` — verifies the wrapper against the committed `emoji.bin`.
+- `scripts/build-xcframework.sh` — produces `Slugkit.xcframework`.

--- a/bindings/swift/Sources/Slugkit/Slugkit.swift
+++ b/bindings/swift/Sources/Slugkit/Slugkit.swift
@@ -1,0 +1,138 @@
+import CSlugkit
+import Foundation
+
+/// An error thrown by the SlugKit engine, carrying the message from the native layer.
+public struct SlugkitError: Error, CustomStringConvertible {
+    public let message: String
+    public init(_ message: String) { self.message = message }
+    public var description: String { message }
+}
+
+/// The capacity of a pattern: how many distinct slugs it can produce, plus the maximum length.
+public struct Capacity {
+    /// Total capacity as a decimal string (the value can exceed 64 bits).
+    public let value: String
+    /// The engine's upper bound on slug length for the pattern.
+    public let maxLength: Int32
+}
+
+/// A deterministic human-readable ID generator backed by one or more compiled binary dictionaries.
+///
+/// Thread-safe for concurrent generation. Construct once and reuse.
+public final class Generator {
+    private let handle: OpaquePointer
+
+    /// Create a generator from one or more compiled binary dictionaries (`.bin`).
+    /// The dictionary bytes are copied internally; the `Data` values need not outlive this call.
+    public init(binaryDictionaries dictionaries: [Data]) throws {
+        var err: UnsafeMutablePointer<CChar>?
+        // Flatten each Data into a stable base-address + length, then hand the C API arrays of both.
+        let handle: OpaquePointer? = Generator.withDataPointers(dictionaries) { datas, lens in
+            slk_generator_create(datas, lens, dictionaries.count, &err)
+        }
+        guard let handle else {
+            throw Generator.takeError(err, fallback: "failed to create generator")
+        }
+        self.handle = handle
+    }
+
+    /// Create a generator from a single compiled binary dictionary.
+    public convenience init(binaryDictionary data: Data) throws {
+        try self.init(binaryDictionaries: [data])
+    }
+
+    deinit { slk_generator_destroy(handle) }
+
+    /// The native library version.
+    public var version: String { String(cString: slk_version()) }
+
+    /// Produce a fresh random seed.
+    public func randomSeed() throws -> String {
+        var err: UnsafeMutablePointer<CChar>?
+        guard let c = slk_random_seed(handle, &err) else {
+            throw Generator.takeError(err, fallback: "failed to produce seed")
+        }
+        defer { slk_string_free(c) }
+        return String(cString: c)
+    }
+
+    /// Compute a pattern's capacity.
+    public func capacity(of pattern: String) throws -> Capacity {
+        var capacityStr: UnsafeMutablePointer<CChar>?
+        var maxLen: Int32 = 0
+        var err: UnsafeMutablePointer<CChar>?
+        let status = slk_capacity(handle, pattern, &capacityStr, &maxLen, &err)
+        guard status == SLK_OK, let capacityStr else {
+            throw Generator.takeError(err, fallback: "failed to compute capacity")
+        }
+        defer { slk_string_free(capacityStr) }
+        return Capacity(value: String(cString: capacityStr), maxLength: maxLen)
+    }
+
+    /// Generate a single slug for `(pattern, seed, sequence)`.
+    public func generate(_ pattern: String, seed: String, sequence: UInt64) throws -> String {
+        var err: UnsafeMutablePointer<CChar>?
+        guard let c = slk_generate_alloc(handle, pattern, seed, sequence, &err) else {
+            throw Generator.takeError(err, fallback: "generation failed")
+        }
+        defer { slk_string_free(c) }
+        return String(cString: c)
+    }
+
+    /// Generate `count` slugs starting at `sequence`, delivering each to `body`.
+    /// Avoids per-slug allocation on the native side.
+    public func generate(
+        _ pattern: String, seed: String, sequence: UInt64, count: Int,
+        _ body: (String) -> Void
+    ) throws {
+        var err: UnsafeMutablePointer<CChar>?
+        let status = withoutActuallyEscaping(body) { body -> slk_status in
+            var sink = body
+            return withUnsafeMutablePointer(to: &sink) { ctx in
+                slk_generate_batch(handle, pattern, seed, sequence, count, { rawCtx, slug, len in
+                    guard let rawCtx, let slug else { return }
+                    let sink = rawCtx.assumingMemoryBound(to: ((String) -> Void).self).pointee
+                    sink(String(cString: slug))
+                }, ctx, &err)
+            }
+        }
+        guard status == SLK_OK else {
+            throw Generator.takeError(err, fallback: "batch generation failed")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Consume a `char*` error out-param: build a Swift string and free the native buffer.
+    private static func takeError(_ err: UnsafeMutablePointer<CChar>?, fallback: String) -> SlugkitError {
+        guard let err else { return SlugkitError(fallback) }
+        defer { slk_string_free(err) }
+        return SlugkitError(String(cString: err))
+    }
+
+    /// Invoke `body` with parallel C arrays of each Data's base address and length.
+    private static func withDataPointers<R>(
+        _ dictionaries: [Data],
+        _ body: (_ datas: UnsafePointer<UnsafePointer<UInt8>?>?, _ lens: UnsafePointer<Int>?) -> R
+    ) -> R {
+        func recurse(_ index: Int, _ ptrs: inout [UnsafePointer<UInt8>?], _ lens: inout [Int]) -> R {
+            if index == dictionaries.count {
+                return ptrs.withUnsafeBufferPointer { pbuf in
+                    lens.withUnsafeBufferPointer { lbuf in
+                        body(pbuf.baseAddress, lbuf.baseAddress)
+                    }
+                }
+            }
+            return dictionaries[index].withUnsafeBytes { raw in
+                ptrs.append(raw.bindMemory(to: UInt8.self).baseAddress)
+                lens.append(raw.count)
+                return recurse(index + 1, &ptrs, &lens)
+            }
+        }
+        var ptrs: [UnsafePointer<UInt8>?] = []
+        var lens: [Int] = []
+        ptrs.reserveCapacity(dictionaries.count)
+        lens.reserveCapacity(dictionaries.count)
+        return recurse(0, &ptrs, &lens)
+    }
+}

--- a/bindings/swift/Tests/SlugkitTests/SlugkitTests.swift
+++ b/bindings/swift/Tests/SlugkitTests/SlugkitTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Foundation
+@testable import Slugkit
+
+final class SlugkitTests: XCTestCase {
+    /// Locate the committed emoji.bin in the generator tree (no need to duplicate the binary here).
+    private func emojiDictionary() throws -> Data {
+        // .../bindings/swift/Tests/SlugkitTests/SlugkitTests.swift -> generator root
+        let genRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // SlugkitTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // swift
+            .deletingLastPathComponent()  // bindings
+            .deletingLastPathComponent()  // generator root
+        let bin = genRoot
+            .appendingPathComponent("slugkit/tests/data/emoji.bin")
+        return try Data(contentsOf: bin)
+    }
+
+    func testVersion() throws {
+        let gen = try Generator(binaryDictionary: emojiDictionary())
+        XCTAssertFalse(gen.version.isEmpty)
+    }
+
+    func testRandomSeedNonEmpty() throws {
+        let gen = try Generator(binaryDictionary: try emojiDictionary())
+        XCTAssertFalse(try gen.randomSeed().isEmpty)
+    }
+
+    func testCapacity() throws {
+        let gen = try Generator(binaryDictionary: try emojiDictionary())
+        let cap = try gen.capacity(of: "{emoji}")
+        XCTAssertEqual(cap.value, "1154")
+        XCTAssertEqual(cap.maxLength, 1)
+    }
+
+    func testDeterministicGeneration() throws {
+        let gen = try Generator(binaryDictionary: try emojiDictionary())
+        let a = try gen.generate("{emoji}", seed: "foobar", sequence: 0)
+        let b = try gen.generate("{emoji}", seed: "foobar", sequence: 0)
+        XCTAssertFalse(a.isEmpty)
+        XCTAssertEqual(a, b)
+    }
+
+    func testBatch() throws {
+        let gen = try Generator(binaryDictionary: try emojiDictionary())
+        var slugs: [String] = []
+        try gen.generate("{emoji}", seed: "foobar", sequence: 0, count: 5) { slugs.append($0) }
+        XCTAssertEqual(slugs.count, 5)
+        // Same seed/sequence as the single-shot call -> first batch slug matches generate(seq: 0).
+        XCTAssertEqual(slugs.first, try gen.generate("{emoji}", seed: "foobar", sequence: 0))
+    }
+
+    func testMalformedPatternThrows() throws {
+        let gen = try Generator(binaryDictionary: try emojiDictionary())
+        XCTAssertThrowsError(try gen.generate("{", seed: "foobar", sequence: 0))
+    }
+}

--- a/bindings/swift/scripts/build-xcframework.sh
+++ b/bindings/swift/scripts/build-xcframework.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build Slugkit.xcframework (macOS + iOS device + iOS simulator) from the userver-free C ABI.
+# The xcframework is a build artifact (gitignored); the Swift package's binaryTarget points at it.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # bindings/swift
+GEN_ROOT="$(cd "$HERE/../.." && pwd)"                      # generator root (contains slugkit/, cmake/)
+MOBILE="$GEN_ROOT/slugkit/mobile"
+BUILD="$HERE/.build/cmake"
+OUT="$HERE/Slugkit.xcframework"
+
+echo "==> Building static libraries (macOS, iOS device, iOS simulator)"
+cmake -S "$MOBILE" -B "$BUILD/macos" -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_OSX_ARCHITECTURES=arm64 >/dev/null
+cmake --build "$BUILD/macos" -j >/dev/null
+
+cmake -S "$MOBILE" -B "$BUILD/ios-device" -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE="$GEN_ROOT/cmake/toolchains/ios-device.cmake" >/dev/null
+cmake --build "$BUILD/ios-device" -j >/dev/null
+
+cmake -S "$MOBILE" -B "$BUILD/ios-sim" -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE="$GEN_ROOT/cmake/toolchains/ios-simulator.cmake" >/dev/null
+cmake --build "$BUILD/ios-sim" -j >/dev/null
+
+echo "==> Merging dependency archives per slice (self-contained static libs)"
+# A CMake static library does not bundle its dependencies, so libslugkit_c.a alone has unresolved
+# fmt/utf8proc symbols. Combine the three archives per slice into one with libtool -static.
+merge_slice() {
+    local slice="$1"
+    libtool -static -no_warning_for_no_symbols -o "$BUILD/$slice/libslugkit_combined.a" \
+        "$BUILD/$slice/libslugkit_c.a" \
+        "$BUILD/$slice/_deps/fmt-build/libfmt.a" \
+        "$BUILD/$slice/_deps/utf8proc-build/libutf8proc.a"
+}
+merge_slice macos
+merge_slice ios-device
+merge_slice ios-sim
+
+echo "==> Staging headers + module map"
+HDR="$BUILD/headers"
+rm -rf "$HDR"; mkdir -p "$HDR"
+cp "$GEN_ROOT/slugkit/include/slugkit/c/slugkit_c.h" "$HDR/"
+cat > "$HDR/module.modulemap" <<'MODMAP'
+module CSlugkit {
+    header "slugkit_c.h"
+    export *
+}
+MODMAP
+
+echo "==> Assembling $OUT"
+rm -rf "$OUT"
+xcodebuild -create-xcframework \
+    -library "$BUILD/macos/libslugkit_combined.a"      -headers "$HDR" \
+    -library "$BUILD/ios-device/libslugkit_combined.a" -headers "$HDR" \
+    -library "$BUILD/ios-sim/libslugkit_combined.a"    -headers "$HDR" \
+    -output "$OUT" >/dev/null
+
+echo "==> Done: $OUT"


### PR DESCRIPTION
## What

The first language binding for `slugkit_c`: an **idiomatic Swift wrapper** distributed as a SwiftPM package backed by a prebuilt **XCFramework** (macOS + iOS device + iOS simulator).

> Stacked on #22 (`feat/mobile-toolchains`) — this PR targets that branch so its diff shows only the Swift files. Merge #22 first.

## How

- **`scripts/build-xcframework.sh`** — cross-compiles the core + C ABI for each Apple platform via the CMake toolchains, merges the fmt/utf8proc archives into a **self-contained static lib per slice** (`libtool -static`, since a CMake static lib doesn't bundle its deps), and assembles `Slugkit.xcframework`.
- **`Package.swift`** — binary `CSlugkit` target (module map over `slugkit_c.h`) + `Slugkit` Swift wrapper target (links `libc++`, as the native lib is C++).
- **`Sources/Slugkit/Slugkit.swift`** — a `Generator` class: create from binary-dictionary `Data`, `randomSeed()`, `capacity(of:)` (arbitrary-precision decimal string), single + batch generation, errors surfaced as `SlugkitError`.

## Testing

`swift test` on macOS — **6/6 pass**, exercising the full chain Swift → C ABI → C++ engine against the committed `emoji.bin`: version, random seed, `capacity({emoji})` = 1154/maxLen 1, deterministic generate, batch, and error on a malformed pattern.

## Notes

- The `Slugkit.xcframework` and `.build/` are git-ignored — reproduced by the build script (no binaries committed).
- Tests locate `emoji.bin` in the generator tree via `#filePath` (no binary duplication).
- Next bindings: Kotlin/Android AAR, then Dart/Flutter ffi.