### PR TITLE
bindings: Kotlin/Android package (JNI + AAR) for the C ABI

### DIFF
--- a/bindings/kotlin/.gitignore
+++ b/bindings/kotlin/.gitignore
@@ -1,0 +1,8 @@
+# Gradle / Android
+.gradle/
+build/
+local.properties
+.cxx/
+
+# Local CMake + Kotlin verification output
+.build/

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -1,0 +1,55 @@
+# Slugkit — Kotlin / Android binding
+
+Idiomatic Kotlin wrapper over the SlugKit generator engine, exposed through a
+JNI bridge (`libslugkit_jni`) and packaged as an Android library (AAR) that
+bundles the native `.so` for each ABI.
+
+## Layout
+
+- `src/main/cpp/slugkit_jni.cpp` — JNI bridge to the `slugkit_c` C ABI.
+- `src/main/cpp/CMakeLists.txt` — builds `libslugkit_jni` (JNI + userver-free
+  core + C ABI); invoked by Gradle per ABI and by the host verifier.
+- `src/main/kotlin/com/slugkit/Slugkit.kt` — the public `Generator` API.
+- `build.gradle.kts` — Android library module (AAR) with `externalNativeBuild`
+  (CMake) for `arm64-v8a`, `armeabi-v7a`, `x86_64`.
+- `scripts/verify-host.sh` + `scripts/Verify.kt` — host-JVM verification.
+
+## Build the AAR
+
+Requires the Android SDK + NDK and Gradle (with an `ANDROID_HOME`):
+
+```sh
+cd bindings/kotlin
+gradle assembleRelease   # -> build/outputs/aar/slugkit-release.aar
+```
+
+## Usage
+
+```kotlin
+import com.slugkit.Generator
+
+val dict: ByteArray = context.assets.open("emoji.bin").readBytes()
+Generator.fromBinaryDictionary(dict).use { gen ->
+    val slug = gen.generate("{emoji}", seed = "foobar", sequence = 0)
+
+    val cap = gen.capacity("{emoji}")          // cap.value (decimal String), cap.maxLength
+
+    val many = gen.generate("{adjective}-{noun}", seed = "s", sequence = 0, count = 100)
+}
+```
+
+`Generator` is thread-safe for concurrent generation; construct once and reuse.
+It is `AutoCloseable` — use `use { ... }` to release the native handle.
+Generation is deterministic: the same `(pattern, seed, sequence)` always yields
+the same slug.
+
+## Verify without an emulator
+
+The JNI bridge and the Kotlin wrapper can be verified on the host JVM (builds the
+native lib for the host, compiles the wrapper with `kotlinc`, runs it against the
+committed `emoji.bin`):
+
+```sh
+./scripts/verify-host.sh
+# -> ALL KOTLIN JNI CHECKS PASSED
+```

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    id("com.android.library") version "8.5.2"
+    id("org.jetbrains.kotlin.android") version "1.9.24"
+}
+
+android {
+    namespace = "com.slugkit"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        ndk {
+            // Ship the .so for the common device + emulator ABIs.
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+        }
+        externalNativeBuild {
+            cmake {
+                // Self-contained native lib (static libc++ so the .so has no external STL dependency).
+                arguments += "-DANDROID_STL=c++_static"
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.24.0+"
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}

--- a/bindings/kotlin/scripts/Verify.kt
+++ b/bindings/kotlin/scripts/Verify.kt
@@ -1,0 +1,37 @@
+package com.slugkit
+
+import java.io.File
+
+// Host-JVM verification of the JNI bridge + Kotlin wrapper. Loads libslugkit_jni from
+// java.library.path and drives the real com.slugkit.Generator API against emoji.bin.
+fun main(args: Array<String>) {
+    require(args.isNotEmpty()) { "usage: Verify <path-to-emoji.bin>" }
+    val emoji = File(args[0]).readBytes()
+
+    Generator.fromBinaryDictionary(emoji).use { gen ->
+        check(gen.version.isNotEmpty()) { "version empty" }
+        check(gen.randomSeed().isNotEmpty()) { "seed empty" }
+
+        val cap = gen.capacity("{emoji}")
+        check(cap.value == "1154") { "capacity=${cap.value}" }
+        check(cap.maxLength == 1) { "maxLength=${cap.maxLength}" }
+
+        val a = gen.generate("{emoji}", "foobar", 0)
+        val b = gen.generate("{emoji}", "foobar", 0)
+        check(a.isNotEmpty() && a == b) { "not deterministic: $a vs $b" }
+
+        val batch = gen.generate("{emoji}", "foobar", 0, 5)
+        check(batch.size == 5) { "batch size=${batch.size}" }
+        check(batch.first() == a) { "batch[0]=${batch.first()} != $a" }
+
+        var threw = false
+        try {
+            gen.generate("{", "foobar", 0)
+        } catch (e: Exception) {
+            threw = true
+        }
+        check(threw) { "malformed pattern should throw" }
+    }
+
+    println("ALL KOTLIN JNI CHECKS PASSED")
+}

--- a/bindings/kotlin/scripts/verify-host.sh
+++ b/bindings/kotlin/scripts/verify-host.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Host-JVM verification of the JNI bridge + Kotlin wrapper (no Android device/emulator needed).
+# Builds libslugkit_jni for the host, compiles the Kotlin wrapper + Verify.kt, and runs them.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # bindings/kotlin
+GEN_ROOT="$(cd "$HERE/../.." && pwd)"                      # generator root
+BUILD="$HERE/.build/host-cmake"
+KOUT="$HERE/.build/kotlin"
+
+echo "==> Building libslugkit_jni for the host"
+cmake -S "$HERE/src/main/cpp" -B "$BUILD" -DCMAKE_BUILD_TYPE=Release >/dev/null
+cmake --build "$BUILD" -j >/dev/null
+
+LIB="$(find "$BUILD" -name 'libslugkit_jni.*' \( -name '*.dylib' -o -name '*.so' \) | head -1)"
+LIBDIR="$(dirname "$LIB")"
+echo "    built $LIB"
+
+echo "==> Compiling Kotlin wrapper + verifier"
+mkdir -p "$KOUT"
+kotlinc "$HERE/src/main/kotlin/com/slugkit/Slugkit.kt" "$HERE/scripts/Verify.kt" \
+    -include-runtime -d "$KOUT/verify.jar" 2>/dev/null
+
+echo "==> Running verification"
+java -Djava.library.path="$LIBDIR" -cp "$KOUT/verify.jar" com.slugkit.VerifyKt \
+    "$GEN_ROOT/slugkit/tests/data/emoji.bin"

--- a/bindings/kotlin/settings.gradle.kts
+++ b/bindings/kotlin/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "slugkit"

--- a/bindings/kotlin/src/main/AndroidManifest.xml
+++ b/bindings/kotlin/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/bindings/kotlin/src/main/cpp/CMakeLists.txt
+++ b/bindings/kotlin/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.24)
+project(slugkit_jni CXX)
+
+# Builds libslugkit_jni.so: the JNI bridge plus the userver-free core + C ABI.
+# Invoked by Gradle (externalNativeBuild) per Android ABI, and by scripts/verify-host.sh on the host.
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Bring in the slugkit_c target (core + C ABI; fetches fmt/utf8proc). Path: this dir is
+# bindings/kotlin/src/main/cpp -> five levels up to the generator root.
+get_filename_component(GEN_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE)
+add_subdirectory("${GEN_ROOT}/slugkit/mobile" "${CMAKE_BINARY_DIR}/slugkit-mobile")
+
+add_library(slugkit_jni SHARED slugkit_jni.cpp)
+target_link_libraries(slugkit_jni PRIVATE slugkit_c)
+
+if(ANDROID)
+    # The NDK toolchain provides jni.h and the log lib.
+    find_library(log-lib log)
+    target_link_libraries(slugkit_jni PRIVATE ${log-lib})
+else()
+    # Host build (verification): locate the JDK's JNI headers.
+    find_package(JNI REQUIRED)
+    target_include_directories(slugkit_jni PRIVATE ${JNI_INCLUDE_DIRS})
+endif()

--- a/bindings/kotlin/src/main/cpp/slugkit_jni.cpp
+++ b/bindings/kotlin/src/main/cpp/slugkit_jni.cpp
@@ -1,0 +1,160 @@
+// JNI bridge from the JVM (Kotlin/Java) to the slugkit_c C ABI.
+//
+// The JVM side is `object com.slugkit.SlugkitJni` with @JvmStatic external funs; its native symbols
+// are Java_com_slugkit_SlugkitJni_<name>. Handles are passed as jlong. Native errors are surface as
+// Java RuntimeExceptions.
+#include <slugkit/c/slugkit_c.h>
+
+#include <jni.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+// Throw java.lang.RuntimeException with `message` (or a native error string) and free it.
+void ThrowRuntime(JNIEnv* env, const char* message) {
+    jclass cls = env->FindClass("java/lang/RuntimeException");
+    if (cls != nullptr) {
+        env->ThrowNew(cls, message != nullptr ? message : "slugkit: unknown error");
+    }
+}
+
+// Consume a slugkit_c char* error out-param into a Java exception (and free it).
+void ThrowFromErr(JNIEnv* env, char* err) {
+    ThrowRuntime(env, err != nullptr ? err : "slugkit: unknown error");
+    slk_string_free(err);
+}
+
+slk_generator* AsGenerator(jlong handle) { return reinterpret_cast<slk_generator*>(handle); }
+
+// Copy a modified-UTF-8 jstring into a std::string (std::string is fine for ASCII/UTF-8 patterns).
+std::string ToUtf8(JNIEnv* env, jstring s) {
+    if (s == nullptr) {
+        return {};
+    }
+    const char* chars = env->GetStringUTFChars(s, nullptr);
+    std::string out{chars != nullptr ? chars : ""};
+    if (chars != nullptr) {
+        env->ReleaseStringUTFChars(s, chars);
+    }
+    return out;
+}
+
+}  // namespace
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL Java_com_slugkit_SlugkitJni_create(JNIEnv* env, jobject, jobjectArray dicts) {
+    const jsize n = dicts != nullptr ? env->GetArrayLength(dicts) : 0;
+    std::vector<std::vector<jbyte>> owned;
+    std::vector<const uint8_t*> datas;
+    std::vector<size_t> lens;
+    owned.reserve(n);
+    datas.reserve(n);
+    lens.reserve(n);
+    for (jsize i = 0; i < n; ++i) {
+        auto arr = reinterpret_cast<jbyteArray>(env->GetObjectArrayElement(dicts, i));
+        const jsize len = env->GetArrayLength(arr);
+        std::vector<jbyte> buf(static_cast<size_t>(len));
+        env->GetByteArrayRegion(arr, 0, len, buf.data());
+        owned.push_back(std::move(buf));
+        datas.push_back(reinterpret_cast<const uint8_t*>(owned.back().data()));
+        lens.push_back(static_cast<size_t>(len));
+        env->DeleteLocalRef(arr);
+    }
+    char* err = nullptr;
+    slk_generator* gen = slk_generator_create(datas.data(), lens.data(), static_cast<size_t>(n), &err);
+    if (gen == nullptr) {
+        ThrowFromErr(env, err);
+        return 0;
+    }
+    return reinterpret_cast<jlong>(gen);
+}
+
+JNIEXPORT void JNICALL Java_com_slugkit_SlugkitJni_destroy(JNIEnv*, jobject, jlong handle) {
+    slk_generator_destroy(AsGenerator(handle));
+}
+
+JNIEXPORT jstring JNICALL Java_com_slugkit_SlugkitJni_randomSeed(JNIEnv* env, jobject, jlong handle) {
+    char* err = nullptr;
+    char* seed = slk_random_seed(AsGenerator(handle), &err);
+    if (seed == nullptr) {
+        ThrowFromErr(env, err);
+        return nullptr;
+    }
+    jstring out = env->NewStringUTF(seed);
+    slk_string_free(seed);
+    return out;
+}
+
+// Returns String[2] = { capacity-decimal, maxLength-as-decimal }.
+JNIEXPORT jobjectArray JNICALL Java_com_slugkit_SlugkitJni_capacity(JNIEnv* env, jobject, jlong handle,
+                                                                    jstring pattern) {
+    const std::string pat = ToUtf8(env, pattern);
+    char* cap = nullptr;
+    int32_t max_len = 0;
+    char* err = nullptr;
+    if (slk_capacity(AsGenerator(handle), pat.c_str(), &cap, &max_len, &err) != SLK_OK) {
+        ThrowFromErr(env, err);
+        return nullptr;
+    }
+    jclass string_cls = env->FindClass("java/lang/String");
+    jobjectArray out = env->NewObjectArray(2, string_cls, nullptr);
+    env->SetObjectArrayElement(out, 0, env->NewStringUTF(cap != nullptr ? cap : "0"));
+    env->SetObjectArrayElement(out, 1, env->NewStringUTF(std::to_string(max_len).c_str()));
+    slk_string_free(cap);
+    return out;
+}
+
+JNIEXPORT jstring JNICALL Java_com_slugkit_SlugkitJni_generate(JNIEnv* env, jobject, jlong handle, jstring pattern,
+                                                               jstring seed, jlong sequence) {
+    const std::string pat = ToUtf8(env, pattern);
+    const std::string sd = ToUtf8(env, seed);
+    char* err = nullptr;
+    char* slug = slk_generate_alloc(AsGenerator(handle), pat.c_str(), sd.c_str(),
+                                    static_cast<uint64_t>(sequence), &err);
+    if (slug == nullptr) {
+        ThrowFromErr(env, err);
+        return nullptr;
+    }
+    jstring out = env->NewStringUTF(slug);
+    slk_string_free(slug);
+    return out;
+}
+
+// Batch: collect into a String[] on the native side, then return it (simple, JVM-idiomatic).
+namespace {
+struct BatchCtx {
+    JNIEnv* env;
+    jobjectArray array;
+    jsize index;
+};
+void EmitToArray(void* ctx, const char* slug, size_t /*len*/) {
+    auto* c = static_cast<BatchCtx*>(ctx);
+    c->env->SetObjectArrayElement(c->array, c->index++, c->env->NewStringUTF(slug));
+}
+}  // namespace
+
+JNIEXPORT jobjectArray JNICALL Java_com_slugkit_SlugkitJni_generateBatch(JNIEnv* env, jobject, jlong handle,
+                                                                         jstring pattern, jstring seed,
+                                                                         jlong sequence, jint count) {
+    const std::string pat = ToUtf8(env, pattern);
+    const std::string sd = ToUtf8(env, seed);
+    jclass string_cls = env->FindClass("java/lang/String");
+    jobjectArray out = env->NewObjectArray(count, string_cls, nullptr);
+    BatchCtx ctx{env, out, 0};
+    char* err = nullptr;
+    if (slk_generate_batch(AsGenerator(handle), pat.c_str(), sd.c_str(), static_cast<uint64_t>(sequence),
+                           static_cast<size_t>(count), EmitToArray, &ctx, &err) != SLK_OK) {
+        ThrowFromErr(env, err);
+        return nullptr;
+    }
+    return out;
+}
+
+JNIEXPORT jstring JNICALL Java_com_slugkit_SlugkitJni_version(JNIEnv* env, jobject) {
+    return env->NewStringUTF(slk_version());
+}
+
+}  // extern "C"

--- a/bindings/kotlin/src/main/kotlin/com/slugkit/Slugkit.kt
+++ b/bindings/kotlin/src/main/kotlin/com/slugkit/Slugkit.kt
@@ -1,0 +1,69 @@
+package com.slugkit
+
+/** The capacity of a pattern: total number of distinct slugs plus the maximum length. */
+data class Capacity(
+    /** Total capacity; may exceed 64 bits, so it is exposed as a decimal string. */
+    val value: String,
+    /** The engine's upper bound on slug length for the pattern. */
+    val maxLength: Int,
+)
+
+/**
+ * A deterministic human-readable ID generator backed by one or more compiled binary dictionaries.
+ *
+ * Thread-safe for concurrent generation. Construct once and reuse; call [close] (or use
+ * `use { ... }`) to release the native handle.
+ */
+class Generator private constructor(private val handle: Long) : AutoCloseable {
+
+    /** The native library version. */
+    val version: String get() = SlugkitJni.version()
+
+    /** Produce a fresh random seed. */
+    fun randomSeed(): String = SlugkitJni.randomSeed(handle)
+
+    /** Compute a pattern's capacity. */
+    fun capacity(pattern: String): Capacity {
+        val (value, maxLen) = SlugkitJni.capacity(handle, pattern)
+        return Capacity(value, maxLen.toInt())
+    }
+
+    /** Generate a single slug for `(pattern, seed, sequence)`. */
+    fun generate(pattern: String, seed: String, sequence: Long): String =
+        SlugkitJni.generate(handle, pattern, seed, sequence)
+
+    /** Generate [count] slugs starting at [sequence]. */
+    fun generate(pattern: String, seed: String, sequence: Long, count: Int): List<String> =
+        SlugkitJni.generateBatch(handle, pattern, seed, sequence, count).asList()
+
+    override fun close() = SlugkitJni.destroy(handle)
+
+    companion object {
+        /** Create a generator from one or more compiled binary dictionaries (`.bin`). */
+        fun fromBinaryDictionaries(dictionaries: List<ByteArray>): Generator =
+            Generator(SlugkitJni.create(dictionaries.toTypedArray()))
+
+        /** Create a generator from a single compiled binary dictionary. */
+        fun fromBinaryDictionary(dictionary: ByteArray): Generator =
+            fromBinaryDictionaries(listOf(dictionary))
+    }
+}
+
+/**
+ * Low-level JNI entry points into libslugkit_jni. Prefer [Generator]; this is public only so the
+ * native symbol names (Java_com_slugkit_SlugkitJni_*) are stable.
+ */
+internal object SlugkitJni {
+    init {
+        System.loadLibrary("slugkit_jni")
+    }
+
+    external fun create(dictionaries: Array<ByteArray>): Long
+    external fun destroy(handle: Long)
+    external fun randomSeed(handle: Long): String
+    /** Returns [value, maxLength] as strings. */
+    external fun capacity(handle: Long, pattern: String): Array<String>
+    external fun generate(handle: Long, pattern: String, seed: String, sequence: Long): String
+    external fun generateBatch(handle: Long, pattern: String, seed: String, sequence: Long, count: Int): Array<String>
+    external fun version(): String
+}


### PR DESCRIPTION
## What

Second language binding for `slugkit_c`: an **idiomatic Kotlin wrapper** over a JNI bridge, packaged as an **Android library (AAR)** that bundles the native `.so` per ABI.

> Stacked on #22 (`feat/mobile-toolchains`); sibling to the Swift binding (#23). Targets the toolchains branch so the diff is only the Kotlin files. Merge #22 first.

## How

- **`src/main/cpp/slugkit_jni.cpp`** — JNI bridge to the C ABI; handles passed as `jlong`, native errors surfaced as Java `RuntimeException`s.
- **`src/main/cpp/CMakeLists.txt`** — builds `libslugkit_jni` linking the mobile `slugkit_c` target (core + C ABI); `jni.h` from the NDK on Android, from the JDK on host.
- **`src/main/kotlin/com/slugkit/Slugkit.kt`** — `Generator` (`AutoCloseable`): `fromBinaryDictionary(ies)`, `randomSeed`, `capacity` (decimal string + max length), single + batch generation.
- **`build.gradle.kts`** — Android library, `externalNativeBuild` (CMake), ABIs `arm64-v8a` / `armeabi-v7a` / `x86_64`, `c++_static`.

## Testing

Verified on the **host JVM** (no emulator): `scripts/verify-host.sh` builds `libslugkit_jni` for the host, compiles the **real Kotlin wrapper with `kotlinc`**, and runs it against the committed `emoji.bin`:

```
ALL KOTLIN JNI CHECKS PASSED
```

covering version, random seed, `capacity({emoji})` = 1154/maxLen 1, deterministic generate, batch of 5, and a malformed pattern throwing. Proves the full chain **Kotlin → JNI → C ABI → C++ engine**.

## Notes

- The AAR build itself requires the Android SDK/NDK + Gradle (not run in CI here); the JNI bridge + wrapper are host-verified.
- Gradle/CMake build outputs are git-ignored.
- Next binding: Dart/Flutter ffi.