### PR TITLE
bindings: Dart/Flutter ffi package for the C ABI

### DIFF
--- a/bindings/dart/.gitignore
+++ b/bindings/dart/.gitignore
@@ -1,0 +1,7 @@
+# Dart / pub
+.dart_tool/
+.packages
+pubspec.lock
+
+# Local native build output
+.build/

--- a/bindings/dart/README.md
+++ b/bindings/dart/README.md
@@ -1,0 +1,49 @@
+# Slugkit — Dart / Flutter binding
+
+Idiomatic Dart wrapper over the SlugKit generator engine's C ABI (`slugkit_c`),
+using `dart:ffi` to bind the native library directly (no platform channel).
+
+## Layout
+
+- `lib/slugkit.dart` — the public `Generator` API.
+- `lib/src/ffi_bindings.dart` — `dart:ffi` lookups over `slugkit_c`.
+- `test/slugkit_test.dart` — verifies the binding against the committed `emoji.bin`.
+- `scripts/build-native.sh` — builds the shared `libslugkit_c` for the host.
+
+## Usage
+
+```dart
+import 'dart:io';
+import 'package:slugkit/slugkit.dart';
+
+final dict = File('emoji.bin').readAsBytesSync();
+final gen = Generator.fromBytes(dict);
+
+final slug = gen.generate('{emoji}', 'foobar', 0);
+
+final cap = gen.capacity('{emoji}');           // cap.value (decimal String), cap.maxLength
+
+final many = gen.generateBatch('{adjective}-{noun}', 's', 0, 100);
+
+gen.dispose();
+```
+
+Generation is deterministic: the same `(pattern, seed, sequence)` always yields
+the same slug. `Generator` is backed by a native handle — call `dispose()` when
+done.
+
+### Loading the native library
+
+`Generator.fromBytes` opens `libslugkit_c` by its platform default name; pass
+`libraryPath:` to load an explicit file. In a Flutter app the shared library is
+bundled per platform (built from `slugkit/mobile` with `-DSLUGKIT_MOBILE_SHARED=ON`,
+reusing the iOS/Android artefacts).
+
+## Test (host)
+
+```sh
+cd bindings/dart
+./scripts/build-native.sh   # builds .build/host/libslugkit_c.dylib|.so
+dart pub get
+dart test                   # 6/6 pass against emoji.bin
+```

--- a/bindings/dart/lib/slugkit.dart
+++ b/bindings/dart/lib/slugkit.dart
@@ -1,0 +1,155 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+
+import 'src/ffi_bindings.dart';
+
+/// An error thrown by the SlugKit engine, carrying the message from the native layer.
+class SlugkitException implements Exception {
+  SlugkitException(this.message);
+  final String message;
+  @override
+  String toString() => 'SlugkitException: $message';
+}
+
+/// The capacity of a pattern: total number of distinct slugs plus the maximum length.
+class Capacity {
+  Capacity(this.value, this.maxLength);
+
+  /// Total capacity; may exceed 64 bits, so it is exposed as a decimal string.
+  final String value;
+
+  /// The engine's upper bound on slug length for the pattern.
+  final int maxLength;
+}
+
+/// A deterministic human-readable ID generator backed by a compiled binary dictionary.
+///
+/// Construct with [Generator.fromBytes], reuse for many generations, and call [dispose]
+/// to release the native handle. Generation is deterministic: the same
+/// `(pattern, seed, sequence)` always yields the same slug.
+class Generator {
+  Generator._(this._bindings, this._handle);
+
+  final SlugkitBindings _bindings;
+  final Pointer<SlkGenerator> _handle;
+  bool _disposed = false;
+
+  /// Open the native library. On most platforms the default name resolves the bundled
+  /// library; pass [libraryPath] to load an explicit file (e.g. in tests).
+  static DynamicLibrary _openLibrary(String? libraryPath) {
+    if (libraryPath != null) return DynamicLibrary.open(libraryPath);
+    if (Platform.isMacOS || Platform.isIOS) return DynamicLibrary.open('libslugkit_c.dylib');
+    if (Platform.isWindows) return DynamicLibrary.open('slugkit_c.dll');
+    return DynamicLibrary.open('libslugkit_c.so');
+  }
+
+  /// Create a generator from a single compiled binary dictionary (`.bin`).
+  factory Generator.fromBytes(Uint8List dictionary, {String? libraryPath, DynamicLibrary? library}) {
+    final bindings = SlugkitBindings(library ?? _openLibrary(libraryPath));
+    final data = malloc<Uint8>(dictionary.length);
+    data.asTypedList(dictionary.length).setAll(0, dictionary);
+    final errPtr = malloc<Pointer<Utf8>>()..value = nullptr;
+    try {
+      final handle = bindings.createOne(data, dictionary.length, errPtr);
+      if (handle == nullptr) {
+        throw SlugkitException(_takeError(bindings, errPtr, 'failed to create generator'));
+      }
+      return Generator._(bindings, handle);
+    } finally {
+      malloc.free(data);
+      malloc.free(errPtr);
+    }
+  }
+
+  /// The native library version.
+  String get version => _bindings.version().toDartString();
+
+  /// Produce a fresh random seed.
+  String randomSeed() {
+    _checkAlive();
+    final errPtr = malloc<Pointer<Utf8>>()..value = nullptr;
+    try {
+      final result = _bindings.randomSeed(_handle, errPtr);
+      if (result == nullptr) {
+        throw SlugkitException(_takeError(_bindings, errPtr, 'failed to produce seed'));
+      }
+      final seed = result.toDartString();
+      _bindings.stringFree(result);
+      return seed;
+    } finally {
+      malloc.free(errPtr);
+    }
+  }
+
+  /// Compute a pattern's capacity.
+  Capacity capacity(String pattern) {
+    _checkAlive();
+    final patternPtr = pattern.toNativeUtf8();
+    final capPtr = malloc<Pointer<Utf8>>()..value = nullptr;
+    final maxLenPtr = malloc<Int32>();
+    final errPtr = malloc<Pointer<Utf8>>()..value = nullptr;
+    try {
+      final status = _bindings.capacity(_handle, patternPtr, capPtr, maxLenPtr, errPtr);
+      if (status != slkOk) {
+        throw SlugkitException(_takeError(_bindings, errPtr, 'failed to compute capacity'));
+      }
+      final value = capPtr.value.toDartString();
+      _bindings.stringFree(capPtr.value);
+      return Capacity(value, maxLenPtr.value);
+    } finally {
+      malloc.free(patternPtr);
+      malloc.free(capPtr);
+      malloc.free(maxLenPtr);
+      malloc.free(errPtr);
+    }
+  }
+
+  /// Generate a single slug for `(pattern, seed, sequence)`.
+  String generate(String pattern, String seed, int sequence) {
+    _checkAlive();
+    final patternPtr = pattern.toNativeUtf8();
+    final seedPtr = seed.toNativeUtf8();
+    final errPtr = malloc<Pointer<Utf8>>()..value = nullptr;
+    try {
+      final result = _bindings.generateAlloc(_handle, patternPtr, seedPtr, sequence, errPtr);
+      if (result == nullptr) {
+        throw SlugkitException(_takeError(_bindings, errPtr, 'generation failed'));
+      }
+      final slug = result.toDartString();
+      _bindings.stringFree(result);
+      return slug;
+    } finally {
+      malloc.free(patternPtr);
+      malloc.free(seedPtr);
+      malloc.free(errPtr);
+    }
+  }
+
+  /// Generate [count] slugs starting at [sequence]. Batch generation is equivalent to
+  /// calling [generate] for `sequence, sequence + 1, ...` (deterministic per sequence).
+  List<String> generateBatch(String pattern, String seed, int sequence, int count) {
+    return List<String>.generate(count, (i) => generate(pattern, seed, sequence + i));
+  }
+
+  /// Release the native handle. The generator must not be used afterwards.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _bindings.destroy(_handle);
+  }
+
+  void _checkAlive() {
+    if (_disposed) throw StateError('Generator has been disposed');
+  }
+
+  static String _takeError(SlugkitBindings b, Pointer<Pointer<Utf8>> errPtr, String fallback) {
+    final err = errPtr.value;
+    if (err == nullptr) return fallback;
+    final message = err.toDartString();
+    b.stringFree(err);
+    return message;
+  }
+}

--- a/bindings/dart/lib/src/ffi_bindings.dart
+++ b/bindings/dart/lib/src/ffi_bindings.dart
@@ -1,0 +1,63 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+
+/// Opaque native generator handle.
+final class SlkGenerator extends Opaque {}
+
+// --- Native signatures ---------------------------------------------------------------------------
+
+typedef _CreateOneNative = Pointer<SlkGenerator> Function(
+    Pointer<Uint8>, Size, Pointer<Pointer<Utf8>>);
+typedef _CreateOneDart = Pointer<SlkGenerator> Function(
+    Pointer<Uint8>, int, Pointer<Pointer<Utf8>>);
+
+typedef _DestroyNative = Void Function(Pointer<SlkGenerator>);
+typedef _DestroyDart = void Function(Pointer<SlkGenerator>);
+
+typedef _RandomSeedNative = Pointer<Utf8> Function(
+    Pointer<SlkGenerator>, Pointer<Pointer<Utf8>>);
+typedef _RandomSeedDart = Pointer<Utf8> Function(
+    Pointer<SlkGenerator>, Pointer<Pointer<Utf8>>);
+
+typedef _CapacityNative = Int32 Function(Pointer<SlkGenerator>, Pointer<Utf8>,
+    Pointer<Pointer<Utf8>>, Pointer<Int32>, Pointer<Pointer<Utf8>>);
+typedef _CapacityDart = int Function(Pointer<SlkGenerator>, Pointer<Utf8>,
+    Pointer<Pointer<Utf8>>, Pointer<Int32>, Pointer<Pointer<Utf8>>);
+
+typedef _GenerateAllocNative = Pointer<Utf8> Function(Pointer<SlkGenerator>,
+    Pointer<Utf8>, Pointer<Utf8>, Uint64, Pointer<Pointer<Utf8>>);
+typedef _GenerateAllocDart = Pointer<Utf8> Function(Pointer<SlkGenerator>,
+    Pointer<Utf8>, Pointer<Utf8>, int, Pointer<Pointer<Utf8>>);
+
+typedef _StringFreeNative = Void Function(Pointer<Utf8>);
+typedef _StringFreeDart = void Function(Pointer<Utf8>);
+
+typedef _VersionNative = Pointer<Utf8> Function();
+typedef _VersionDart = Pointer<Utf8> Function();
+
+/// Thin lookup table over `libslugkit_c` exposing the C ABI to Dart.
+class SlugkitBindings {
+  SlugkitBindings(DynamicLibrary lib)
+      : createOne =
+            lib.lookupFunction<_CreateOneNative, _CreateOneDart>('slk_generator_create_one'),
+        destroy = lib.lookupFunction<_DestroyNative, _DestroyDart>('slk_generator_destroy'),
+        randomSeed =
+            lib.lookupFunction<_RandomSeedNative, _RandomSeedDart>('slk_random_seed'),
+        capacity = lib.lookupFunction<_CapacityNative, _CapacityDart>('slk_capacity'),
+        generateAlloc = lib
+            .lookupFunction<_GenerateAllocNative, _GenerateAllocDart>('slk_generate_alloc'),
+        stringFree =
+            lib.lookupFunction<_StringFreeNative, _StringFreeDart>('slk_string_free'),
+        version = lib.lookupFunction<_VersionNative, _VersionDart>('slk_version');
+
+  final _CreateOneDart createOne;
+  final _DestroyDart destroy;
+  final _RandomSeedDart randomSeed;
+  final _CapacityDart capacity;
+  final _GenerateAllocDart generateAlloc;
+  final _StringFreeDart stringFree;
+  final _VersionDart version;
+}
+
+/// Status codes returned by the C ABI (mirrors `slk_status`).
+const int slkOk = 0;

--- a/bindings/dart/pubspec.yaml
+++ b/bindings/dart/pubspec.yaml
@@ -1,0 +1,13 @@
+name: slugkit
+description: Dart/Flutter binding for the SlugKit generator engine via dart:ffi.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  ffi: ^2.1.0
+
+dev_dependencies:
+  test: ^1.24.0

--- a/bindings/dart/scripts/build-native.sh
+++ b/bindings/dart/scripts/build-native.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build the shared libslugkit_c for the host so `dart test` can load it via ffi.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # bindings/dart
+GEN_ROOT="$(cd "$HERE/../.." && pwd)"                      # generator root
+BUILD="$HERE/.build/host"
+
+cmake -S "$GEN_ROOT/slugkit/mobile" -B "$BUILD" \
+    -DCMAKE_BUILD_TYPE=Release -DSLUGKIT_MOBILE_SHARED=ON >/dev/null
+cmake --build "$BUILD" -j >/dev/null
+
+echo "Built shared library in $BUILD"
+ls "$BUILD"/libslugkit_c.* 2>/dev/null || true

--- a/bindings/dart/test/slugkit_test.dart
+++ b/bindings/dart/test/slugkit_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:slugkit/slugkit.dart';
+import 'package:test/test.dart';
+
+String _firstExisting(List<String> paths) =>
+    paths.firstWhere((p) => File(p).existsSync(), orElse: () => paths.first);
+
+void main() {
+  // The native library is built by scripts/build-native.sh (or pass SLUGKIT_LIB).
+  final libPath = Platform.environment['SLUGKIT_LIB'] ??
+      _firstExisting([
+        '.build/host/libslugkit_c.dylib',
+        '.build/host/libslugkit_c.so',
+      ]);
+  final emojiPath = Platform.environment['SLUGKIT_EMOJI_BIN'] ??
+      '../../slugkit/tests/data/emoji.bin';
+  final dict = File(emojiPath).readAsBytesSync();
+
+  Generator open() => Generator.fromBytes(dict, libraryPath: libPath);
+
+  test('version is non-empty', () {
+    final g = open();
+    expect(g.version, isNotEmpty);
+    g.dispose();
+  });
+
+  test('random seed is non-empty', () {
+    final g = open();
+    expect(g.randomSeed(), isNotEmpty);
+    g.dispose();
+  });
+
+  test('capacity of {emoji}', () {
+    final g = open();
+    final cap = g.capacity('{emoji}');
+    expect(cap.value, '1154');
+    expect(cap.maxLength, 1);
+    g.dispose();
+  });
+
+  test('generation is deterministic', () {
+    final g = open();
+    final a = g.generate('{emoji}', 'foobar', 0);
+    final b = g.generate('{emoji}', 'foobar', 0);
+    expect(a, isNotEmpty);
+    expect(a, b);
+    g.dispose();
+  });
+
+  test('batch generates count slugs, aligned with single-shot', () {
+    final g = open();
+    final batch = g.generateBatch('{emoji}', 'foobar', 0, 5);
+    expect(batch.length, 5);
+    expect(batch.first, g.generate('{emoji}', 'foobar', 0));
+    g.dispose();
+  });
+
+  test('malformed pattern throws', () {
+    final g = open();
+    expect(() => g.generate('{', 'foobar', 0), throwsA(isA<SlugkitException>()));
+    g.dispose();
+  });
+}


### PR DESCRIPTION
## What

Third language binding for `slugkit_c`: an **idiomatic Dart wrapper** using `dart:ffi` to bind the native library directly — no platform channel, no glue layer.

> Stacked on #22 (`feat/mobile-toolchains`); sibling to Swift (#23) and Kotlin (#24). Targets the toolchains branch so the diff is only the Dart files. Merge #22 first.

## How

- **`lib/src/ffi_bindings.dart`** — `dart:ffi` typedefs + lookups over the C ABI.
- **`lib/slugkit.dart`** — a `Generator` (`Generator.fromBytes`): `version`, `randomSeed`, `capacity` (decimal string + max length), single + batch generation, errors as `SlugkitException`; native handle released via `dispose()`.
- **`scripts/build-native.sh`** — builds the shared `libslugkit_c` for the host (`-DSLUGKIT_MOBILE_SHARED=ON`).

Batch is a Dart loop over `generate(sequence + i)` — deterministic per sequence, so it matches the native batch output while keeping the FFI surface callback-free.

## Testing

`dart test` — **6/6 pass** against the committed `emoji.bin` (version, random seed, `capacity({emoji})` = 1154/maxLen 1, deterministic generate, batch of 5 aligned with single-shot, malformed pattern throwing). Proves **Dart → dart:ffi → C ABI → C++ engine**.

## Notes

- For Flutter, the shared library is bundled per platform, reusing the iOS/Android artefacts from the toolchains.
- `.dart_tool/`, `.build/`, `pubspec.lock` are git-ignored.

---

This completes the three planned language bindings (Swift #23, Kotlin #24, Dart #25), all on top of the C ABI (#21) and cross-toolchains (#22).