### PR TITLE
tests: multi-dictionary word-pattern harness across C ABI + bindings

### DIFF
--- a/bindings/dart/README.md
+++ b/bindings/dart/README.md
@@ -21,6 +21,9 @@ final gen = Generator.fromBytes(dict);
 
 final slug = gen.generate('{emoji}', 'foobar', 0);
 
+// Several dictionaries (e.g. an adjective + a noun dictionary for {adjective}-{noun}):
+final multi = Generator.fromMultiple([adjectiveBin, nounBin]);
+
 final cap = gen.capacity('{emoji}');           // cap.value (decimal String), cap.maxLength
 
 final many = gen.generateBatch('{adjective}-{noun}', 's', 0, 100);

--- a/bindings/dart/lib/slugkit.dart
+++ b/bindings/dart/lib/slugkit.dart
@@ -64,6 +64,40 @@ class Generator {
     }
   }
 
+  /// Create a generator from several compiled binary dictionaries (e.g. an adjective and a noun
+  /// dictionary for `{adjective}-{noun}`). The bytes are copied; the lists need not outlive this call.
+  factory Generator.fromMultiple(List<Uint8List> dictionaries,
+      {String? libraryPath, DynamicLibrary? library}) {
+    final bindings = SlugkitBindings(library ?? _openLibrary(libraryPath));
+    final n = dictionaries.length;
+    final datas = malloc<Pointer<Uint8>>(n);
+    final lens = malloc<IntPtr>(n);
+    final errPtr = malloc<Pointer<Utf8>>()..value = nullptr;
+    final buffers = <Pointer<Uint8>>[];
+    try {
+      for (var i = 0; i < n; i++) {
+        final dict = dictionaries[i];
+        final buf = malloc<Uint8>(dict.length);
+        buf.asTypedList(dict.length).setAll(0, dict);
+        buffers.add(buf);
+        datas[i] = buf;
+        lens[i] = dict.length;
+      }
+      final handle = bindings.create(datas, lens, n, errPtr);
+      if (handle == nullptr) {
+        throw SlugkitException(_takeError(bindings, errPtr, 'failed to create generator'));
+      }
+      return Generator._(bindings, handle);
+    } finally {
+      for (final b in buffers) {
+        malloc.free(b);
+      }
+      malloc.free(datas);
+      malloc.free(lens);
+      malloc.free(errPtr);
+    }
+  }
+
   /// The native library version.
   String get version => _bindings.version().toDartString();
 

--- a/bindings/dart/lib/src/ffi_bindings.dart
+++ b/bindings/dart/lib/src/ffi_bindings.dart
@@ -11,6 +11,13 @@ typedef _CreateOneNative = Pointer<SlkGenerator> Function(
 typedef _CreateOneDart = Pointer<SlkGenerator> Function(
     Pointer<Uint8>, int, Pointer<Pointer<Utf8>>);
 
+// const uint8_t* const* datas, const size_t* lens, size_t n, char** err_out.
+// The lens array uses IntPtr (pointer-width, matching size_t on all targets).
+typedef _CreateNative = Pointer<SlkGenerator> Function(
+    Pointer<Pointer<Uint8>>, Pointer<IntPtr>, Size, Pointer<Pointer<Utf8>>);
+typedef _CreateDart = Pointer<SlkGenerator> Function(
+    Pointer<Pointer<Uint8>>, Pointer<IntPtr>, int, Pointer<Pointer<Utf8>>);
+
 typedef _DestroyNative = Void Function(Pointer<SlkGenerator>);
 typedef _DestroyDart = void Function(Pointer<SlkGenerator>);
 
@@ -40,6 +47,7 @@ class SlugkitBindings {
   SlugkitBindings(DynamicLibrary lib)
       : createOne =
             lib.lookupFunction<_CreateOneNative, _CreateOneDart>('slk_generator_create_one'),
+        create = lib.lookupFunction<_CreateNative, _CreateDart>('slk_generator_create'),
         destroy = lib.lookupFunction<_DestroyNative, _DestroyDart>('slk_generator_destroy'),
         randomSeed =
             lib.lookupFunction<_RandomSeedNative, _RandomSeedDart>('slk_random_seed'),
@@ -51,6 +59,7 @@ class SlugkitBindings {
         version = lib.lookupFunction<_VersionNative, _VersionDart>('slk_version');
 
   final _CreateOneDart createOne;
+  final _CreateDart create;
   final _DestroyDart destroy;
   final _RandomSeedDart randomSeed;
   final _CapacityDart capacity;

--- a/bindings/dart/test/slugkit_test.dart
+++ b/bindings/dart/test/slugkit_test.dart
@@ -15,9 +15,14 @@ void main() {
       ]);
   final emojiPath = Platform.environment['SLUGKIT_EMOJI_BIN'] ??
       '../../slugkit/tests/data/emoji.bin';
+  final adverbPath = Platform.environment['SLUGKIT_ADVERB_BIN'] ??
+      '../../slugkit/tests/data/test-adv.slugs';
   final dict = File(emojiPath).readAsBytesSync();
+  final adverb = File(adverbPath).readAsBytesSync();
 
   Generator open() => Generator.fromBytes(dict, libraryPath: libPath);
+  Generator openMulti() =>
+      Generator.fromMultiple([adverb, dict], libraryPath: libPath);
 
   test('version is non-empty', () {
     final g = open();
@@ -60,5 +65,40 @@ void main() {
     final g = open();
     expect(() => g.generate('{', 'foobar', 0), throwsA(isA<SlugkitException>()));
     g.dispose();
+  });
+
+  // Multi-dictionary: load adverb + emoji (n=2) and generate real word patterns.
+  // Golden values (seed "foobar") are byte-identical across all language bindings.
+  group('multi-dictionary word patterns', () {
+    test('capacity of {adverb}-{emoji}', () {
+      final g = openMulti();
+      final cap = g.capacity('{adverb}-{emoji}');
+      expect(cap.value, '4176326');
+      expect(cap.maxLength, 22);
+      g.dispose();
+    });
+
+    test('{adverb}-{emoji} golden prefixes', () {
+      final g = openMulti();
+      expect(g.generate('{adverb}-{emoji}', 'foobar', 0), startsWith('lustfully-'));
+      expect(g.generate('{adverb}-{emoji}', 'foobar', 1), startsWith('abroad-'));
+      expect(g.generate('{adverb}-{emoji}', 'foobar', 2), startsWith('maladroitly-'));
+      g.dispose();
+    });
+
+    test('{adverb:<=5}-{number:3d} golden values', () {
+      final g = openMulti();
+      expect(g.generate('{adverb:<=5}-{number:3d}', 'foobar', 0), 'ago-887');
+      expect(g.generate('{adverb:<=5}-{number:3d}', 'foobar', 1), 'aloud-774');
+      expect(g.generate('{adverb:<=5}-{number:3d}', 'foobar', 2), 'apart-661');
+      g.dispose();
+    });
+
+    test('batch of a large capacity pattern is collision-free', () {
+      final g = openMulti();
+      final slugs = g.generateBatch('{adverb}-{emoji}', 'foobar', 0, 20);
+      expect(slugs.toSet().length, 20);
+      g.dispose();
+    });
   });
 }

--- a/bindings/kotlin/scripts/Verify.kt
+++ b/bindings/kotlin/scripts/Verify.kt
@@ -5,8 +5,9 @@ import java.io.File
 // Host-JVM verification of the JNI bridge + Kotlin wrapper. Loads libslugkit_jni from
 // java.library.path and drives the real com.slugkit.Generator API against emoji.bin.
 fun main(args: Array<String>) {
-    require(args.isNotEmpty()) { "usage: Verify <path-to-emoji.bin>" }
+    require(args.size >= 2) { "usage: Verify <path-to-emoji.bin> <path-to-test-adv.slugs>" }
     val emoji = File(args[0]).readBytes()
+    val adverb = File(args[1]).readBytes()
 
     Generator.fromBinaryDictionary(emoji).use { gen ->
         check(gen.version.isNotEmpty()) { "version empty" }
@@ -31,6 +32,25 @@ fun main(args: Array<String>) {
             threw = true
         }
         check(threw) { "malformed pattern should throw" }
+    }
+
+    // Multi-dictionary (adverb + emoji, n=2) with real word patterns.
+    // Golden values (seed "foobar") are byte-identical across all language bindings.
+    Generator.fromBinaryDictionaries(listOf(adverb, emoji)).use { gen ->
+        val cap = gen.capacity("{adverb}-{emoji}")
+        check(cap.value == "4176326") { "multi capacity=${cap.value}" }
+        check(cap.maxLength == 22) { "multi maxLength=${cap.maxLength}" }
+
+        check(gen.generate("{adverb}-{emoji}", "foobar", 0).startsWith("lustfully-")) { "seq0 prefix" }
+        check(gen.generate("{adverb}-{emoji}", "foobar", 1).startsWith("abroad-")) { "seq1 prefix" }
+        check(gen.generate("{adverb}-{emoji}", "foobar", 2).startsWith("maladroitly-")) { "seq2 prefix" }
+
+        check(gen.generate("{adverb:<=5}-{number:3d}", "foobar", 0) == "ago-887") { "num seq0" }
+        check(gen.generate("{adverb:<=5}-{number:3d}", "foobar", 1) == "aloud-774") { "num seq1" }
+        check(gen.generate("{adverb:<=5}-{number:3d}", "foobar", 2) == "apart-661") { "num seq2" }
+
+        val batch = gen.generate("{adverb}-{emoji}", "foobar", 0, 20)
+        check(batch.toSet().size == 20) { "batch not collision-free: ${batch.toSet().size}" }
     }
 
     println("ALL KOTLIN JNI CHECKS PASSED")

--- a/bindings/kotlin/scripts/verify-host.sh
+++ b/bindings/kotlin/scripts/verify-host.sh
@@ -23,4 +23,5 @@ kotlinc "$HERE/src/main/kotlin/com/slugkit/Slugkit.kt" "$HERE/scripts/Verify.kt"
 
 echo "==> Running verification"
 java -Djava.library.path="$LIBDIR" -cp "$KOUT/verify.jar" com.slugkit.VerifyKt \
-    "$GEN_ROOT/slugkit/tests/data/emoji.bin"
+    "$GEN_ROOT/slugkit/tests/data/emoji.bin" \
+    "$GEN_ROOT/slugkit/tests/data/test-adv.slugs"

--- a/bindings/swift/Tests/SlugkitTests/SlugkitTests.swift
+++ b/bindings/swift/Tests/SlugkitTests/SlugkitTests.swift
@@ -17,6 +17,48 @@ final class SlugkitTests: XCTestCase {
         return try Data(contentsOf: bin)
     }
 
+    private func adverbDictionary() throws -> Data {
+        let genRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // SlugkitTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // swift
+            .deletingLastPathComponent()  // bindings
+            .deletingLastPathComponent()  // generator root
+        return try Data(contentsOf: genRoot.appendingPathComponent("slugkit/tests/data/test-adv.slugs"))
+    }
+
+    /// Multi-dictionary (adverb + emoji, n=2). Golden values (seed "foobar") are byte-identical
+    /// across all language bindings.
+    private func multi() throws -> Generator {
+        try Generator(binaryDictionaries: [adverbDictionary(), emojiDictionary()])
+    }
+
+    func testMultiCapacity() throws {
+        let cap = try multi().capacity(of: "{adverb}-{emoji}")
+        XCTAssertEqual(cap.value, "4176326")
+        XCTAssertEqual(cap.maxLength, 22)
+    }
+
+    func testMultiGoldenPrefixes() throws {
+        let gen = try multi()
+        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 0).hasPrefix("lustfully-"))
+        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 1).hasPrefix("abroad-"))
+        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 2).hasPrefix("maladroitly-"))
+    }
+
+    func testMultiLengthAndNumberGolden() throws {
+        let gen = try multi()
+        XCTAssertEqual(try gen.generate("{adverb:<=5}-{number:3d}", seed: "foobar", sequence: 0), "ago-887")
+        XCTAssertEqual(try gen.generate("{adverb:<=5}-{number:3d}", seed: "foobar", sequence: 1), "aloud-774")
+        XCTAssertEqual(try gen.generate("{adverb:<=5}-{number:3d}", seed: "foobar", sequence: 2), "apart-661")
+    }
+
+    func testMultiBatchCollisionFree() throws {
+        var slugs: [String] = []
+        try multi().generate("{adverb}-{emoji}", seed: "foobar", sequence: 0, count: 20) { slugs.append($0) }
+        XCTAssertEqual(Set(slugs).count, 20)
+    }
+
     func testVersion() throws {
         let gen = try Generator(binaryDictionary: emojiDictionary())
         XCTAssertFalse(gen.version.isEmpty)

--- a/slugkit/host/CMakeLists.txt
+++ b/slugkit/host/CMakeLists.txt
@@ -77,6 +77,7 @@ add_test(NAME golden_test COMMAND golden_test)
 add_executable(c_abi_test ${CMAKE_CURRENT_SOURCE_DIR}/c_abi_test.c)
 set_target_properties(c_abi_test PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_definitions(c_abi_test PRIVATE
-    SLK_EMOJI_BIN_PATH="${SLUGKIT_DIR}/tests/data/emoji.bin")
+    SLK_EMOJI_BIN_PATH="${SLUGKIT_DIR}/tests/data/emoji.bin"
+    SLK_ADVERB_BIN_PATH="${SLUGKIT_DIR}/tests/data/test-adv.slugs")
 target_link_libraries(c_abi_test PRIVATE slugkit-generator-host)
 add_test(NAME c_abi_test COMMAND c_abi_test)

--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -106,6 +106,54 @@ int main(void) {
     char* bad = slk_generate_alloc(gen, "{", fixed_seed, 0, &err);
     CHECK(bad == NULL, "malformed pattern returns NULL");
 
+    /* --- multi-dictionary word patterns: load adverb + emoji dictionaries (n=2) --- */
+    /* Golden values below (seed "foobar") are byte-identical across every language binding. */
+    {
+        size_t la = 0, le = 0;
+        unsigned char* adv = read_file(SLK_ADVERB_BIN_PATH, &la);
+        unsigned char* emo = read_file(SLK_EMOJI_BIN_PATH, &le);
+        CHECK(adv != NULL && emo != NULL, "read adverb + emoji dictionaries");
+        const uint8_t* datas[2] = {adv, emo};
+        const size_t lens[2] = {la, le};
+        char* merr = NULL;
+        slk_generator* mg = slk_generator_create(datas, lens, 2, &merr);
+        CHECK(mg != NULL, "create generator from two dictionaries");
+        free(adv);
+        free(emo);
+
+        if (mg != NULL) {
+            char* mc = NULL;
+            int32_t mml = 0;
+            slk_capacity(mg, "{adverb}-{emoji}", &mc, &mml, &err);
+            CHECK(mc && strcmp(mc, "4176326") == 0 && mml == 22, "capacity({adverb}-{emoji}) == 4176326");
+            slk_string_free(mc);
+
+            /* {adverb}-{emoji}: adverb prefix is ASCII and deterministic (emoji suffix varies by build's font, not bytes) */
+            char* w0 = slk_generate_alloc(mg, "{adverb}-{emoji}", "foobar", 0, &err);
+            char* w1 = slk_generate_alloc(mg, "{adverb}-{emoji}", "foobar", 1, &err);
+            char* w2 = slk_generate_alloc(mg, "{adverb}-{emoji}", "foobar", 2, &err);
+            CHECK(w0 && strncmp(w0, "lustfully-", 10) == 0, "{adverb}-{emoji} seq0 starts 'lustfully-'");
+            CHECK(w1 && strncmp(w1, "abroad-", 7) == 0, "{adverb}-{emoji} seq1 starts 'abroad-'");
+            CHECK(w2 && strncmp(w2, "maladroitly-", 12) == 0, "{adverb}-{emoji} seq2 starts 'maladroitly-'");
+            slk_string_free(w0);
+            slk_string_free(w1);
+            slk_string_free(w2);
+
+            /* length constraint + number generator, fully ASCII golden */
+            char* n0 = slk_generate_alloc(mg, "{adverb:<=5}-{number:3d}", "foobar", 0, &err);
+            char* n1 = slk_generate_alloc(mg, "{adverb:<=5}-{number:3d}", "foobar", 1, &err);
+            char* n2 = slk_generate_alloc(mg, "{adverb:<=5}-{number:3d}", "foobar", 2, &err);
+            CHECK(n0 && strcmp(n0, "ago-887") == 0, "{adverb:<=5}-{number:3d} seq0 == ago-887");
+            CHECK(n1 && strcmp(n1, "aloud-774") == 0, "{adverb:<=5}-{number:3d} seq1 == aloud-774");
+            CHECK(n2 && strcmp(n2, "apart-661") == 0, "{adverb:<=5}-{number:3d} seq2 == apart-661");
+            slk_string_free(n0);
+            slk_string_free(n1);
+            slk_string_free(n2);
+
+            slk_generator_destroy(mg);
+        }
+    }
+
     slk_string_free(a);
     slk_string_free(b);
     slk_string_free(cap);


### PR DESCRIPTION
## What

Real test harnesses that **load dictionary files and generate word patterns** across the C ABI and all three language bindings — using the two binary dictionaries already committed in the repo (`test-adv.slugs` = adverbs, `emoji.bin`). No new fixtures.

Until now every binding test loaded only the single-kind `emoji.bin` with a trivial `{emoji}` pattern, so the **multi-dictionary load path and real word patterns were untested everywhere**. This also surfaced and fixes a gap: the **Dart** binding had no multi-dictionary constructor.

## Golden values (seed `"foobar"`) — byte-identical across every binding

```
capacity({adverb}-{emoji})           = 4176326, maxLength 22
{adverb}-{emoji}         seq 0..2     -> lustfully-…, abroad-…, maladroitly-…
{adverb:<=5}-{number:3d} seq 0..2     -> ago-887, aloud-774, apart-661
```

The `{adverb}-{emoji}` cases assert the ASCII adverb prefix (emoji glyph bytes aren't pinned); the length+number pattern is asserted in full.

## Changes

- **C ABI** (`slugkit/host/c_abi_test.c`): loads both dicts via `slk_generator_create` (n=2); asserts capacity, adverb prefixes, length+number golden, and that a 20-slug batch is collision-free. Adverb path wired through the host CMake.
- **Dart**: adds the missing `Generator.fromMultiple` (binds `slk_generator_create`) + multi-dict tests.
- **Swift / Kotlin**: multi-dict tests via their existing multi-dictionary constructors.

## Testing (all run locally)

- C ABI host test: **passes** (incl. new multi-dict checks)
- `dart test`: **10/10**
- `swift test`: **10/10**
- Kotlin host verifier: **ALL KOTLIN JNI CHECKS PASSED**

All four produce the same golden slugs — cross-language byte-identical output through the shared C++ engine.