### PR TITLE
fix: scramble large permutation ranges (emoji unique first-element stuck)

### DIFF
--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -106,6 +106,26 @@ int main(void) {
     char* bad = slk_generate_alloc(gen, "{", fixed_seed, 0, &err);
     CHECK(bad == NULL, "malformed pattern returns NULL");
 
+    /* Regression: {emoji:count=5 unique=true} has capacity > 2^32; consecutive sequences must vary
+     * in the FIRST emoji (a bug made the permutation cluster so the first emoji stayed fixed for
+     * hundreds of sequences). Compare the leading bytes of the first codepoint across sequences. */
+    {
+        const char* upat = "{emoji:count=5 unique=true}";
+        char* u0 = slk_generate_alloc(gen, upat, "aaa", 0, &err);
+        char* u1 = slk_generate_alloc(gen, upat, "aaa", 1, &err);
+        char* u2 = slk_generate_alloc(gen, upat, "aaa", 2, &err);
+        char* u0b = slk_generate_alloc(gen, upat, "aaa", 0, &err);
+        CHECK(u0 && u1 && u2 && u0b, "unique-emoji generation succeeds");
+        CHECK(u0 && u0b && strcmp(u0, u0b) == 0, "unique-emoji generation is deterministic");
+        /* first emoji differs across consecutive sequences (leading 4 bytes not all identical) */
+        CHECK(u0 && u1 && u2 && !(strncmp(u0, u1, 4) == 0 && strncmp(u1, u2, 4) == 0),
+              "unique-emoji first emoji varies across sequences");
+        slk_string_free(u0);
+        slk_string_free(u1);
+        slk_string_free(u2);
+        slk_string_free(u0b);
+    }
+
     /* --- multi-dictionary word patterns: load adverb + emoji dictionaries (n=2) --- */
     /* Golden values below (seed "foobar") are byte-identical across every language binding. */
     {

--- a/slugkit/src/slugkit/generator/permutations.cpp
+++ b/slugkit/src/slugkit/generator/permutations.cpp
@@ -148,7 +148,34 @@ auto Permute(std::uint64_t max_value, std::uint32_t hash, std::uint64_t sequence
     if (!(max_value & (max_value - 1))) {
         return PermutePowerOf2(max_value, hash, sequence, rounds);
     }
-    return LCGPermute(max_value, hash, sequence);
+    // LCGPermute is a valid bijection but a weak scrambler: consecutive sequence numbers differ in
+    // the output by ~`multiplier` (< 2^32, derived from the 32-bit hash). Once `max_value` exceeds
+    // 2^32 that difference is tiny relative to the range, so the high-order part of the output barely
+    // changes across consecutive sequences. This is visible e.g. in `{emoji:count=5 unique=true}`,
+    // where the first emoji (the most significant "digit" of the permuted index) stays fixed for
+    // hundreds of sequences. For large ranges use cycle-walking over the enclosing power of two with
+    // the Feistel permutation, which mixes all bits. Small ranges keep LCGPermute so existing IDs
+    // remain byte-identical.
+    if (max_value <= 0xFFFFFFFFull) {
+        return LCGPermute(max_value, hash, sequence);
+    }
+    // Cycle-walking format-preserving permutation: permute within [0, 2^bits) (the smallest power of
+    // two >= max_value) and re-permute until the result lands in [0, max_value). The Feistel map is a
+    // bijection over the power-of-two domain, so restricting it to the subrange is a bijection too.
+    // Expected iterations < 2 because 2^bits < 2 * max_value.
+    //
+    // The Feistel network is only a bijection over an ODD-width domain with an EVEN number of rounds
+    // (with odd rounds the unbalanced halves don't realign and it collapses to half the range). The
+    // enclosing domain here can be odd-width, so force an even round count to keep the map bijective
+    // regardless of the caller's `rounds` (the default, 4, is already even -> no change in practice).
+    std::uint32_t even_rounds = rounds + (rounds & 1u);
+    std::uint32_t bits = 64 - __builtin_clzll(max_value - 1);
+    std::uint64_t domain = bits >= 64 ? 0 : (1ull << bits);  // 0 selects the 2^64 domain in PermutePowerOf2
+    std::uint64_t value = sequence % max_value;
+    do {
+        value = PermutePowerOf2(domain, hash, value, even_rounds);
+    } while (value >= max_value);
+    return value;
 }
 
 //-------------------------------------------------------------

--- a/slugkit/tests/permutation_test.cpp
+++ b/slugkit/tests/permutation_test.cpp
@@ -149,4 +149,47 @@ UTEST(PermutationGen, PermuteNonUniqueUniqueness) {
     );
 }
 
+// Regression: for ranges above 2^32 the permutation must mix the high bits, so consecutive sequence
+// numbers change the most-significant part of the output. Previously LCGPermute clustered them (the
+// output moved by only ~multiplier < 2^32 per step), which e.g. kept the first emoji of
+// {emoji:count=5 unique=true} fixed for hundreds of sequences.
+UTEST(PermutationGen, PermuteLargeRangeMixesHighBits) {
+    constexpr std::uint64_t kMaxValue = 2028900546777600ULL;  // UniquePermutationCount(1150, 5)
+    constexpr std::uint64_t kBucket = kMaxValue / 1150;       // width of the leading "digit"
+
+    std::set<std::uint64_t> high_digits;
+    for (std::uint64_t i = 0; i < 16; ++i) {
+        auto value = Permute(kMaxValue, "aaa", i);
+        EXPECT_LT(value, kMaxValue);
+        EXPECT_EQ(value, Permute(kMaxValue, "aaa", i));  // deterministic
+        high_digits.insert(value / kBucket);
+    }
+    // Before the fix this was 1 (the leading digit never changed); now it should be ~16.
+    EXPECT_GE(high_digits.size(), 8u);
+}
+
+// The cycle-walking permutation for large non-power-of-two ranges relies on PermutePowerOf2 being a
+// bijection over its 2^bits domain -- including ODD bit widths (the enclosing domain of the
+// emoji-unique capacity is 51 bits). The Feistel network is only bijective over an odd-width domain
+// with an EVEN round count, so this guards the default (kDefaultRounds = 4).
+UTEST(PermutationGen, PermutePowerOfTwoBijectionOddAndEven) {
+    for (std::uint32_t bits : {5u, 7u, 8u, 9u, 12u, 13u}) {
+        std::uint64_t domain = 1ull << bits;
+        CheckUniqueness<std::uint64_t>(domain, [domain](std::uint64_t i) {
+            return PermutePowerOf2(domain, "test", i);
+        });
+    }
+}
+
+UTEST(PermutationGen, PermuteLargeRangeSampledUniqueness) {
+    constexpr std::uint64_t kMaxValue = 5000000000ULL;  // > 2^32, not a power of two
+    std::set<std::uint64_t> values;
+    for (std::uint64_t i = 0; i < 2000; ++i) {
+        auto value = Permute(kMaxValue, "test", i, 4);
+        EXPECT_LT(value, kMaxValue);
+        values.insert(value);
+    }
+    EXPECT_EQ(values.size(), 2000u);  // collision-free over the sample (still a bijection)
+}
+
 }  // namespace slugkit::generator


### PR DESCRIPTION
## Bug

With `{emoji:count=5 unique=true}` (and any large emoji count), the **first emoji stays fixed for hundreds of consecutive sequences** — reported from the Flutter sample app:

```
seq 0  ℹ️↔️💳💙🩹
seq 1  ℹ️↕️🇩🇯🇦🇩🧇
seq 2  ℹ️↕️😮‍💨🕷️🦏
...        ^ first (and nearly the second) emoji never change
```

## Cause

Emoji-unique generation (1) picks a permutation **index** in `[0, total_permutations)` — for count=5 that's `1150·1149·…·1146 ≈ 2×10¹⁵` — then (2) factorial-decomposes it into the emoji tuple, so the most-significant digit **is the first emoji**.

Step 1 used `LCGPermute`: `(mult·seq + inc) % max_value`, with `mult`/`inc` from a **32-bit** hash (< 2^32). LCG is a valid bijection but weak: consecutive sequences differ in the output by only ~`mult`. Once `max_value` exceeds 2^32, that step is tiny relative to the range, so the high part of the index barely moves ⇒ first emoji stuck.

## Fix

For `max_value > 2^32`, permute via **cycle-walking over the enclosing power of two** using the existing Feistel permutation (mixes all bits; a proper pseudorandom permutation, no arithmetic-progression structure). Ranges ≤ 2^32 keep `LCGPermute` **unchanged**.

Blast radius is deliberately minimal: existing IDs for the common patterns (words, small numbers, single `{emoji}`) stay **byte-identical**. Only single placeholders whose index space exceeds 2^32 change — the previously-broken large emoji counts and very large number generators (`{number:11d}`+).

After the fix:
```
seq 0  ❌😽😿😻🇸🇧
seq 1  🇨🇩🥚🦊🦠😼
seq 2  🐨👉🦶🏷️🦢
```

## Is the cycle-walk collision-free? Yes — provably.

Cycle-walking rejects out-of-range results and **re-permutes** (it does *not* truncate or `% N` into range, which is what would collide). Restricting a permutation of `[0, 2^bits)` to `[0, N)` this way is itself a bijection on `[0, N)` (standard FPE construction). Termination is guaranteed (`m` is in-range on a finite cycle; expected < 2 iterations since `2^bits < 2N`).

Verified by **full enumeration**, not sampling:
- `PermutePowerOf2` is a bijection over `2^bits` for every width **3–16** (odd and even).
- The cycle-walk is a bijection over many non-power-of-two `N` (odd/even enclosing domains) — every case `N/N` distinct.

Subtlety guarded: the Feistel is only bijective over an **odd-width** domain with an **even** round count (odd rounds collapse it to half the range, e.g. `2^7, rounds=3 → 64/128`). The emoji domain is 51-bit, so the cycle-walk **forces an even round count** — the default (4) is already even, so real output is unchanged.

## Why not just widen the LCG multiplier?

That fixes the visible symptom cheaply, but LCG stays an affine map: `out[i] = (mult·i + inc) mod N` is an arithmetic progression, so consecutive outputs always differ by a constant step (mod N) — detectable structure in the IDs. Feistel is a pseudorandom permutation with no such structure, and it matches what the power-of-two path already uses (so both paths now have consistent quality).

## Verification

- **All existing goldens intact** — host `golden_test` 9/9, `c_abi_test` all pass, `dart test` 10/10.
- Emoji-unique first element now varies every sequence; the leading digit takes **15 distinct values over 16 sequences** (was **1**).

Regression tests: `permutation_test.cpp` (PermutePowerOf2 odd/even bijection, large-range high-bit mixing, large-range sampled uniqueness) and `c_abi_test.c` (unique-emoji first element varies).