### PR TITLE
feat: placeholder alternation `{a}|{b}`

### DIFF
--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -170,6 +170,19 @@ int main(void) {
             slk_string_free(n1);
             slk_string_free(n2);
 
+            /* Placeholder alternation: capacity is the sum of the children (adverb + emoji). */
+            char* ac = NULL;
+            slk_capacity(mg, "{adverb}|{emoji}", &ac, NULL, &err);
+            CHECK(ac && strcmp(ac, "4773") == 0, "capacity({adverb}|{emoji}) == 4773 (3619 adverbs + 1154 emoji)");
+            slk_string_free(ac);
+            /* Escaped pipe is a literal pipe in the output. */
+            char* esc = slk_generate_alloc(mg, "x\\|y", "s", 0, &err);
+            CHECK(esc && strcmp(esc, "x|y") == 0, "escaped pipe `x\\|y` -> `x|y`");
+            slk_string_free(esc);
+            /* A bare unescaped pipe is a parse error. */
+            char* bar = slk_generate_alloc(mg, "a|b", "s", 0, &err);
+            CHECK(bar == NULL, "unescaped `|` outside alternation is rejected");
+
             slk_generator_destroy(mg);
         }
     }

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -175,6 +175,35 @@ TEST(PatternGenerator, GetCapacity) {
     EXPECT_EQ(PatternGenerator(dictionaries, "{adjective}-{noun}"_pattern_ptr).GetCapacity(), 35);
 }
 
+// Placeholder alternation: {a}|{b} chooses one child. Capacity is the sum of the children's
+// capacities, it is deterministic, and collision-free over that capacity.
+TEST(PatternGenerator, Alternation) {
+    auto dictionaries = MakeDictionarySet();
+    // noun=5, verb=10, adjective=7.
+    EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{verb}"_pattern_ptr).GetCapacity(), 5 + 10);
+    EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{adjective}"_pattern_ptr).GetCapacity(), 5 + 7);
+    EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{verb}|{adjective}"_pattern_ptr).GetCapacity(), 5 + 10 + 7);
+    // Surrounding text keeps a single alternation placeholder.
+    EXPECT_EQ(PatternGenerator(dictionaries, "x-{noun}|{verb}-y"_pattern_ptr).GetCapacity(), 15);
+
+    PatternGenerator generator(dictionaries, "{noun}|{verb}"_pattern_ptr);
+    auto seed_hash = PatternGenerator::SeedHash(kTestSeed);
+    std::set<std::string> nouns{"noun1", "noun2", "noun3", "noun4", "noun5"};
+    std::set<std::string> verbs;
+    for (int i = 1; i <= 10; ++i) {
+        verbs.insert("verb" + std::to_string(i));
+    }
+    const auto capacity = static_cast<std::uint64_t>(generator.GetCapacity());
+    ASSERT_EQ(capacity, 15u);
+    std::set<std::string> seen;
+    for (std::uint64_t i = 0; i < capacity; ++i) {
+        auto slug = generator(seed_hash, i);
+        EXPECT_TRUE(nouns.count(slug) == 1 || verbs.count(slug) == 1) << slug;
+        seen.insert(slug);
+    }
+    EXPECT_EQ(seen.size(), capacity);  // collision-free: all 15 distinct
+}
+
 // End-to-end generator: committed full-slug expectations from generator_test.cpp (GenerateID).
 TEST(Generator, GenerateID) {
     Generator generator(MakeDictionarySet());

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -188,20 +188,20 @@ TEST(PatternGenerator, Alternation) {
 
     PatternGenerator generator(dictionaries, "{noun}|{verb}"_pattern_ptr);
     auto seed_hash = PatternGenerator::SeedHash(kTestSeed);
-    std::set<std::string> nouns{"noun1", "noun2", "noun3", "noun4", "noun5"};
-    std::set<std::string> verbs;
-    for (int i = 1; i <= 10; ++i) {
-        verbs.insert("verb" + std::to_string(i));
-    }
-    const auto capacity = static_cast<std::uint64_t>(generator.GetCapacity());
-    ASSERT_EQ(capacity, 15u);
+    // Golden: the exact deterministic output over the full cycle (seed "foobar"). Also collision-free
+    // (all 15 distinct: five nouns interleaved with ten verbs).
+    const std::vector<std::string> kExpected = {
+        "verb7", "noun1", "verb10", "noun4", "verb3",  "noun2", "verb6", "verb5",
+        "verb9", "verb8", "verb2",  "verb1", "noun5",  "verb4", "noun3",
+    };
+    ASSERT_EQ(kExpected.size(), 15u);
     std::set<std::string> seen;
-    for (std::uint64_t i = 0; i < capacity; ++i) {
+    for (std::uint64_t i = 0; i < kExpected.size(); ++i) {
         auto slug = generator(seed_hash, i);
-        EXPECT_TRUE(nouns.count(slug) == 1 || verbs.count(slug) == 1) << slug;
+        EXPECT_EQ(slug, kExpected[i]) << "seq " << i;
         seen.insert(slug);
     }
-    EXPECT_EQ(seen.size(), capacity);  // collision-free: all 15 distinct
+    EXPECT_EQ(seen.size(), kExpected.size());  // collision-free
 }
 
 // End-to-end generator: committed full-slug expectations from generator_test.cpp (GenerateID).

--- a/slugkit/include/slugkit/generator/pattern.hpp
+++ b/slugkit/include/slugkit/generator/pattern.hpp
@@ -27,7 +27,25 @@ namespace slugkit::generator {
 /// The pattern captures the pattern source and child selectors are string views
 /// into the source.
 struct Pattern {
-    using PatternElement = std::variant<Selector, NumberGen, SpecialCharGen, EmojiGen>;
+    /// @brief A single (non-alternating) placeholder.
+    using SimplePlaceholder = std::variant<Selector, NumberGen, SpecialCharGen, EmojiGen>;
+
+    /// @brief An alternation chooses one of several child placeholders deterministically, the same
+    /// way case mutations pick a cased form: its capacity is the sum of the children's capacities,
+    /// and a sequence value selects a child block and the offset within it.
+    /// @note Placeholder-level alternation only for now: the children are simple placeholders, not
+    /// nested alternations.
+    struct Alternation {
+        std::vector<SimplePlaceholder> alternatives;
+
+        /// @brief Canonical, re-parseable representation, e.g. "{noun}|{verb}".
+        [[nodiscard]] auto ToString() const -> std::string;
+        [[nodiscard]] auto GetHash() const -> std::int64_t;
+        [[nodiscard]] auto Complexity() const -> std::int32_t;
+        [[nodiscard]] auto IsNSFW() const -> bool;
+    };
+
+    using PatternElement = std::variant<Selector, NumberGen, SpecialCharGen, EmojiGen, Alternation>;
     using Placeholders = std::vector<PatternElement>;
     using TextChunks = std::vector<std::string_view>;
     using Substitutions = std::vector<std::string>;
@@ -92,7 +110,10 @@ public:
     using Substitutions = Pattern::Substitutions;
 
 public:
-    SlugFormatter(const Pattern& pattern);
+    /// @param unescape_text When true (generation), backslash escapes in the arbitrary text (e.g.
+    /// `\|`, `\{`) are resolved to their literal character. When false (canonical ToString), the
+    /// text is emitted verbatim so the result round-trips through the parser.
+    explicit SlugFormatter(const Pattern& pattern, bool unescape_text = true);
 
     /// @brief Format the pattern with the substitutions.
     /// @param substitutions The substitutions to use.
@@ -101,6 +122,7 @@ public:
 
 private:
     const Pattern& pattern_;
+    bool unescape_text_;
 };
 
 namespace literals {

--- a/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
+++ b/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
@@ -67,6 +67,12 @@ struct PatternParser {
                 selector.language = language;
             }
         }
+        // Global settings propagate into alternation children (which are simple placeholders).
+        void operator()(Pattern::Alternation& alternation) const {
+            for (auto& child : alternation.alternatives) {
+                std::visit(*this, child);
+            }
+        }
         void operator()(auto&&) const {
         }
     };
@@ -76,6 +82,12 @@ struct PatternParser {
         void operator()(Selector& selector) const {
             if (!selector.exclude_tags.contains(tag)) {
                 selector.include_tags.insert(tag);
+            }
+        }
+        // Global settings propagate into alternation children (which are simple placeholders).
+        void operator()(Pattern::Alternation& alternation) const {
+            for (auto& child : alternation.alternatives) {
+                std::visit(*this, child);
             }
         }
         void operator()(auto&&) const {
@@ -89,6 +101,12 @@ struct PatternParser {
                 selector.exclude_tags.insert(tag);
             }
         }
+        // Global settings propagate into alternation children (which are simple placeholders).
+        void operator()(Pattern::Alternation& alternation) const {
+            for (auto& child : alternation.alternatives) {
+                std::visit(*this, child);
+            }
+        }
         void operator()(auto&&) const {
         }
     };
@@ -100,6 +118,12 @@ struct PatternParser {
                 selector.size_limit = size_limit;
             }
         }
+        // Global settings propagate into alternation children (which are simple placeholders).
+        void operator()(Pattern::Alternation& alternation) const {
+            for (auto& child : alternation.alternatives) {
+                std::visit(*this, child);
+            }
+        }
         void operator()(auto&&) const {
         }
     };
@@ -107,7 +131,8 @@ struct PatternParser {
     using position_t = std::string_view::const_iterator;
 
     constexpr static char kEscapeChar = '\\';
-    constexpr static std::string_view kEscapedChars = "\\{}[]";
+    constexpr static char kAlternationChar = '|';
+    constexpr static std::string_view kEscapedChars = "\\{}[]|";
     constexpr static std::string_view kNumberKeyword = "number";
     constexpr static std::string_view kNumKeword = "num";
     constexpr static std::string_view kSpecialCharKeyword = "special";
@@ -186,7 +211,7 @@ struct PatternParser {
     }
 
     bool IsArbitraryText(char c) const {
-        return c != '{' && c != '}' && c != '[' && c != ']' && c != kEscapeChar;
+        return c != '{' && c != '}' && c != '[' && c != ']' && c != kEscapeChar && c != kAlternationChar;
     }
 
     void SkipArbitraryText() {
@@ -497,7 +522,14 @@ struct PatternParser {
         return result;
     }
 
-    Pattern::PatternElement ParseElement() {
+    // Widen a simple placeholder into a top-level pattern element (which also admits Alternation).
+    static Pattern::PatternElement ToPatternElement(Pattern::SimplePlaceholder&& simple) {
+        return std::visit(
+            [](auto&& arg) -> Pattern::PatternElement { return std::forward<decltype(arg)>(arg); }, std::move(simple)
+        );
+    }
+
+    Pattern::SimplePlaceholder ParseElement() {
         SkipWhitespace();
         if (IsEof()) {
             return {};
@@ -577,8 +609,29 @@ struct PatternParser {
                 text_chunks.push_back(std::string_view(arbitrary_start, pos_));
                 Next();
                 auto element = ParseElement();
-                result.push_back(std::move(element));
                 Expect('}');
+                // Alternation: `{a}|{b}|...` (whitespace allowed around `|`). A run of pipe-separated
+                // placeholders becomes a single Alternation element.
+                auto element_end = pos_;
+                SkipWhitespace();
+                if (Match(kAlternationChar)) {
+                    std::vector<Pattern::SimplePlaceholder> alternatives;
+                    alternatives.push_back(std::move(element));
+                    do {
+                        Next();  // consume '|'
+                        SkipWhitespace();
+                        Expect('{');
+                        alternatives.push_back(ParseElement());
+                        Expect('}');
+                        element_end = pos_;
+                        SkipWhitespace();
+                    } while (Match(kAlternationChar));
+                    pos_ = element_end;  // trailing whitespace after the last alternative is text
+                    result.push_back(Pattern::Alternation{std::move(alternatives)});
+                } else {
+                    pos_ = element_end;  // no alternation; the skipped whitespace is arbitrary text
+                    result.push_back(ToPatternElement(std::move(element)));
+                }
                 arbitrary_start = pos_;
             } else if (Match('[')) {
                 arbitrary_text_end = pos_;
@@ -600,7 +653,14 @@ struct PatternParser {
                     );
                 }
                 ExpectOneOf(kEscapedChars);
-                // TODO handle escaped characters in substitutions.
+                // The escape (backslash + char) stays in the arbitrary-text run and is resolved at
+                // format time (SlugFormatter un-escapes `\X` -> `X`).
+            } else if (Match(kAlternationChar)) {
+                throw PatternSyntaxError(fmt::format(
+                    "Pattern parse error: unexpected `|` at column {}; alternation must be between "
+                    "placeholders (`{{a}}|{{b}}`); escape as `\\|` for a literal pipe",
+                    GetCurrentColumn()
+                ));
             } else {
                 throw PatternSyntaxError(
                     fmt::format("Pattern parse error: unexpected character at column {}", GetCurrentColumn())

--- a/slugkit/src/slugkit/generator/pattern.cpp
+++ b/slugkit/src/slugkit/generator/pattern.cpp
@@ -20,10 +20,59 @@ std::string Pattern::ToString() const {
     std::vector<std::string> substitutions;
     for (const auto& element : placeholders) {
         std::visit(
-            [&substitutions](auto&& arg) { substitutions.push_back(fmt::format("{{{}}}", arg.ToString())); }, element
+            [&substitutions](auto&& arg) {
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, Alternation>) {
+                    // Alternation::ToString already yields "{a}|{b}" with its own braces.
+                    substitutions.push_back(arg.ToString());
+                } else {
+                    substitutions.push_back(fmt::format("{{{}}}", arg.ToString()));
+                }
+            },
+            element
         );
     }
-    return SlugFormatter(*this)(substitutions);
+    // Canonical output must round-trip through the parser, so keep the arbitrary text verbatim
+    // (escapes preserved).
+    return SlugFormatter(*this, /*unescape_text=*/false)(substitutions);
+}
+
+std::string Pattern::Alternation::ToString() const {
+    std::string result;
+    bool first = true;
+    for (const auto& alt : alternatives) {
+        if (!first) {
+            result += '|';
+        }
+        first = false;
+        std::visit([&result](auto&& arg) { result += fmt::format("{{{}}}", arg.ToString()); }, alt);
+    }
+    return result;
+}
+
+std::int64_t Pattern::Alternation::GetHash() const {
+    std::size_t seed = 0;
+    for (const auto& alt : alternatives) {
+        std::visit([&seed](auto&& arg) { boost::hash_combine(seed, arg.GetHash()); }, alt);
+    }
+    return seed;
+}
+
+std::int32_t Pattern::Alternation::Complexity() const {
+    std::int32_t cost = 0;
+    for (const auto& alt : alternatives) {
+        std::visit([&cost](auto&& arg) { cost += arg.Complexity(); }, alt);
+    }
+    return cost;
+}
+
+bool Pattern::Alternation::IsNSFW() const {
+    for (const auto& alt : alternatives) {
+        if (std::holds_alternative<Selector>(alt) && std::get<Selector>(alt).IsNSFW()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 std::string Pattern::Format(Substitutions substitutions) const {
@@ -38,6 +87,10 @@ bool Pattern::IsNSFW() const {
     for (const auto& element : placeholders) {
         if (std::holds_alternative<Selector>(element)) {
             if (std::get<Selector>(element).IsNSFW()) {
+                return true;
+            }
+        } else if (std::holds_alternative<Alternation>(element)) {
+            if (std::get<Alternation>(element).IsNSFW()) {
                 return true;
             }
         }
@@ -84,8 +137,29 @@ Pattern ParsePattern(std::string_view pattern) {
     return Pattern(std::string(pattern));
 }
 
-SlugFormatter::SlugFormatter(const Pattern& pattern)
-    : pattern_(pattern) {
+namespace {
+
+// Append arbitrary text, optionally resolving backslash escapes (`\X` -> `X`). Called for each text
+// chunk during formatting; the parser guarantees every backslash is followed by an escapable char.
+void AppendText(std::string& result, std::string_view chunk, bool unescape) {
+    if (!unescape) {
+        result.append(chunk);
+        return;
+    }
+    for (std::size_t i = 0; i < chunk.size(); ++i) {
+        if (chunk[i] == '\\' && i + 1 < chunk.size()) {
+            result.push_back(chunk[++i]);
+        } else {
+            result.push_back(chunk[i]);
+        }
+    }
+}
+
+}  // namespace
+
+SlugFormatter::SlugFormatter(const Pattern& pattern, bool unescape_text)
+    : pattern_(pattern)
+    , unescape_text_(unescape_text) {
 }
 
 std::string SlugFormatter::operator()(Substitutions substitutions) const {
@@ -110,12 +184,12 @@ std::string SlugFormatter::operator()(Substitutions substitutions) const {
     auto substitution_iter = substitutions.begin();
 
     while (substitution_iter != substitutions.end()) {
-        result.append(*text_chunk_iter);
+        AppendText(result, *text_chunk_iter, unescape_text_);
         text_chunk_iter++;
         result.append(*substitution_iter);
         substitution_iter++;
     }
-    result.append(*text_chunk_iter);
+    AppendText(result, *text_chunk_iter, unescape_text_);
 
     return result;
 }

--- a/slugkit/src/slugkit/generator/pattern_generator.cpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.cpp
@@ -328,6 +328,39 @@ numeric::BigInt EmojiSubstitutionGeneratorBase::GetCapacity() const {
 }
 
 //-------------------------------------------------------------
+// AlternationSubstitutionGenerator
+//-------------------------------------------------------------
+AlternationSubstitutionGenerator::AlternationSubstitutionGenerator(std::vector<SubstitutionGeneratorPtr> children)
+    : children_{std::move(children)}
+    , max_length_{0} {
+    if (children_.empty()) {
+        throw std::runtime_error("Alternation must have at least one alternative");
+    }
+    cumulative_caps_.reserve(children_.size());
+    numeric::BigInt total{0};
+    for (const auto& child : children_) {
+        total += child->GetCapacity();
+        // uint64 prefix sums for the block-selection Permute (matching special/emoji cumulative caps).
+        cumulative_caps_.push_back(static_cast<std::uint64_t>(total));
+        max_length_ = std::max(max_length_, child->GetMaxLength());
+    }
+    capacity_ = total;
+}
+
+std::string AlternationSubstitutionGenerator::Generate(std::uint32_t seed, std::size_t sequence_number) const {
+    auto total = cumulative_caps_.back();
+    // Permute over the whole sum, then split into (child block, offset within block). The offset
+    // becomes the child's sequence, so as the sum's values sweep a block the child sees each of its
+    // own indices exactly once -> collision-free.
+    auto p = Permute(total, seed, sequence_number);
+    auto it = std::upper_bound(cumulative_caps_.begin(), cumulative_caps_.end(), p);
+    auto idx = static_cast<std::size_t>(std::distance(cumulative_caps_.begin(), it));
+    std::uint64_t block_start = idx == 0 ? 0 : cumulative_caps_[idx - 1];
+    std::uint64_t offset = p - block_start;
+    return children_[idx]->Generate(seed, offset);
+}
+
+//-------------------------------------------------------------
 // PatternGenerator::Impl
 //-------------------------------------------------------------
 namespace {
@@ -364,6 +397,54 @@ auto EmojiSelector(const EmojiGen& emoji_gen) -> Selector {
     selector.include_tags = emoji_gen.include_tags;
     selector.exclude_tags = emoji_gen.exclude_tags;
     return selector;
+}
+
+// Build a generator for one simple (non-alternating) placeholder. Used for alternation children.
+// Unlike the top-level path, selectors here use the plain dictionary size (no prime/LCM
+// maximization, which is a flat-composition heuristic; children compose by sum) and are not stored
+// in PatternSettings::selectors, so the settings format for alternation-free patterns is unchanged.
+template <typename DictSet>
+auto BuildSimpleGenerator(const DictSet& dictionaries, const Pattern::SimplePlaceholder& element)
+    -> SubstitutionGeneratorPtr {
+    if (std::holds_alternative<Selector>(element)) {
+        const auto& selector = std::get<Selector>(element);
+        auto filtered_dict = dictionaries.Filter(selector);
+        if (!filtered_dict || filtered_dict->empty()) {
+            throw PatternSyntaxError("No matching words found for: " + selector.ToString());
+        }
+        auto original_size = static_cast<std::int64_t>(filtered_dict->size());
+        auto selected_size = filtered_dict->GetCase() == CaseType::kMixed
+                                 ? static_cast<std::int64_t>(filtered_dict->MixedCapacity())
+                                 : original_size;
+        return MakeSelectorGenerator(filtered_dict, SelectorSettings{original_size, selected_size});
+    }
+    if (std::holds_alternative<NumberGen>(element)) {
+        const auto& number_gen = std::get<NumberGen>(element);
+        if (number_gen.base == NumberBase::kRoman || number_gen.base == NumberBase::kRomanLower) {
+            return std::make_unique<RomanSubstitutionGenerator>(number_gen);
+        }
+        return std::make_unique<NumberSubstitutionGenerator>(number_gen);
+    }
+    if (std::holds_alternative<SpecialCharGen>(element)) {
+        return std::make_unique<SpecialSubstitutionGenerator>(std::get<SpecialCharGen>(element));
+    }
+    const auto& emoji_gen = std::get<EmojiGen>(element);
+    auto emoji_dict = dictionaries.Filter(EmojiSelector(emoji_gen));
+    if (!emoji_dict || emoji_dict->empty()) {
+        throw PatternSyntaxError("No matching emoji found for: " + emoji_gen.ToString());
+    }
+    return MakeEmojiGenerator(emoji_dict, emoji_gen);
+}
+
+template <typename DictSet>
+auto BuildAlternationGenerator(const DictSet& dictionaries, const Pattern::Alternation& alternation)
+    -> SubstitutionGeneratorPtr {
+    std::vector<SubstitutionGeneratorPtr> children;
+    children.reserve(alternation.alternatives.size());
+    for (const auto& alternative : alternation.alternatives) {
+        children.push_back(BuildSimpleGenerator(dictionaries, alternative));
+    }
+    return std::make_unique<AlternationSubstitutionGenerator>(std::move(children));
 }
 
 }  // namespace
@@ -467,6 +548,10 @@ struct PatternGenerator::Impl {
                     throw PatternSyntaxError("No matching emoji found for: " + emoji_gen.ToString());
                 }
                 generators.push_back(MakeEmojiGenerator(emoji_dict, emoji_gen));
+            } else if (std::holds_alternative<Pattern::Alternation>(element)) {
+                generators.push_back(
+                    BuildAlternationGenerator(dictionaries, std::get<Pattern::Alternation>(element))
+                );
             }
             capacity = lcm(capacity, generators.back()->GetCapacity());
             max_pattern_length += generators.back()->GetMaxLength();
@@ -508,6 +593,10 @@ struct PatternGenerator::Impl {
                     throw PatternSyntaxError("No matching emoji found for: " + emoji_gen.ToString());
                 }
                 generators.push_back(MakeEmojiGenerator(emoji_dict, emoji_gen));
+            } else if (std::holds_alternative<Pattern::Alternation>(element)) {
+                generators.push_back(
+                    BuildAlternationGenerator(dictionaries, std::get<Pattern::Alternation>(element))
+                );
             }
             capacity = lcm(capacity, generators.back()->GetCapacity());
             max_pattern_length += generators.back()->GetMaxLength();

--- a/slugkit/src/slugkit/generator/pattern_generator.hpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.hpp
@@ -207,6 +207,34 @@ private:
     binary::FilteredDictionaryConstPtr dictionary_;
 };
 
+/// @brief Substitution generator that chooses one of several child generators (placeholder
+/// alternation `{a}|{b}`). Its capacity is the sum of the children's capacities: a sequence value is
+/// permuted over that sum, selecting a child block and the offset within it (the offset becomes the
+/// child's sequence). This is collision-free -- each value in [0, sum) maps to a distinct
+/// (child, child output) -- and deterministic, the same way case mutations pick a cased form.
+class AlternationSubstitutionGenerator : public SubstitutionGenerator {
+public:
+    explicit AlternationSubstitutionGenerator(std::vector<SubstitutionGeneratorPtr> children);
+    ~AlternationSubstitutionGenerator() override = default;
+
+    std::string Generate(std::uint32_t seed, std::size_t sequence_number) const override;
+
+    numeric::BigInt GetCapacity() const override {
+        return capacity_;
+    }
+    std::size_t GetMaxLength() const override {
+        return max_length_;
+    }
+
+private:
+    std::vector<SubstitutionGeneratorPtr> children_;
+    // Cumulative child capacities (prefix sums) for block selection; uint64 for Permute, matching the
+    // special/emoji cumulative-cap generators.
+    std::vector<std::uint64_t> cumulative_caps_;
+    numeric::BigInt capacity_;
+    std::size_t max_length_;
+};
+
 //-------------------------------------------------------------
 // PatternGenerator
 //-------------------------------------------------------------

--- a/slugkit/tests/generator_test.cpp
+++ b/slugkit/tests/generator_test.cpp
@@ -417,4 +417,29 @@ UTEST(Generator, GenerateWithEmoji) {
     }
 }
 
+UTEST(PatternGenerator, Alternation) {
+    // Capacity is the sum of the children's capacities (noun=5, verb=10, adjective=7).
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{verb}"_pattern_ptr).GetCapacity(), 15);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{adjective}"_pattern_ptr).GetCapacity(), 12);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{verb}|{adjective}"_pattern_ptr).GetCapacity(), 22);
+    // Surrounding text keeps a single alternation placeholder.
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "x-{noun}|{verb}-y"_pattern_ptr).GetCapacity(), 15);
+
+    // Deterministic, collision-free over the capacity; every slug is one of the children's outputs.
+    PatternGenerator generator(kDictionariesSet, "{noun}|{verb}"_pattern_ptr);
+    auto seed_hash = PatternGenerator::SeedHash(kTestSeed);
+    std::set<std::string> nouns{"noun1", "noun2", "noun3", "noun4", "noun5"};
+    std::set<std::string> verbs;
+    for (int i = 1; i <= 10; ++i) {
+        verbs.insert("verb" + std::to_string(i));
+    }
+    std::set<std::string> seen;
+    for (std::uint64_t i = 0; i < 15; ++i) {
+        auto slug = generator(seed_hash, i);
+        EXPECT_TRUE(nouns.count(slug) == 1 || verbs.count(slug) == 1) << slug;
+        seen.insert(slug);
+    }
+    EXPECT_EQ(seen.size(), 15);
+}
+
 }  // namespace slugkit::generator

--- a/slugkit/tests/generator_test.cpp
+++ b/slugkit/tests/generator_test.cpp
@@ -425,21 +425,21 @@ UTEST(PatternGenerator, Alternation) {
     // Surrounding text keeps a single alternation placeholder.
     EXPECT_EQ(PatternGenerator(kDictionariesSet, "x-{noun}|{verb}-y"_pattern_ptr).GetCapacity(), 15);
 
-    // Deterministic, collision-free over the capacity; every slug is one of the children's outputs.
+    // Golden: exact deterministic output over the full cycle (seed "foobar"), and collision-free
+    // (all 15 distinct: five nouns interleaved with ten verbs).
     PatternGenerator generator(kDictionariesSet, "{noun}|{verb}"_pattern_ptr);
     auto seed_hash = PatternGenerator::SeedHash(kTestSeed);
-    std::set<std::string> nouns{"noun1", "noun2", "noun3", "noun4", "noun5"};
-    std::set<std::string> verbs;
-    for (int i = 1; i <= 10; ++i) {
-        verbs.insert("verb" + std::to_string(i));
-    }
+    const std::vector<std::string> kExpected = {
+        "verb7", "noun1", "verb10", "noun4", "verb3",  "noun2", "verb6", "verb5",
+        "verb9", "verb8", "verb2",  "verb1", "noun5",  "verb4", "noun3",
+    };
     std::set<std::string> seen;
-    for (std::uint64_t i = 0; i < 15; ++i) {
+    for (std::uint64_t i = 0; i < kExpected.size(); ++i) {
         auto slug = generator(seed_hash, i);
-        EXPECT_TRUE(nouns.count(slug) == 1 || verbs.count(slug) == 1) << slug;
+        EXPECT_EQ(slug, kExpected[i]) << "seq " << i;
         seen.insert(slug);
     }
-    EXPECT_EQ(seen.size(), 15);
+    EXPECT_EQ(seen.size(), kExpected.size());
 }
 
 }  // namespace slugkit::generator

--- a/slugkit/tests/pattern_test.cpp
+++ b/slugkit/tests/pattern_test.cpp
@@ -633,4 +633,45 @@ UTEST(SlugFormatter, Multiple) {
     EXPECT_THROW(formatter({"test"}), SlugFormatError);
 }
 
+UTEST(PlaceholdersParser, Alternation) {
+    {
+        auto placeholders = ParsePlaceholders("{noun}|{verb}");
+        ASSERT_EQ(placeholders.size(), 1);
+        ASSERT_TRUE(std::holds_alternative<Pattern::Alternation>(placeholders[0]));
+        const auto& alternation = std::get<Pattern::Alternation>(placeholders[0]);
+        ASSERT_EQ(alternation.alternatives.size(), 2);
+        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[0]));
+        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[1]));
+    }
+    {
+        // Whitespace around the pipe is allowed; alternatives may be of mixed placeholder kinds.
+        auto placeholders = ParsePlaceholders("{noun} | {number:2d} | {emoji}");
+        ASSERT_EQ(placeholders.size(), 1);
+        const auto& alternation = std::get<Pattern::Alternation>(placeholders[0]);
+        ASSERT_EQ(alternation.alternatives.size(), 3);
+        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[0]));
+        EXPECT_TRUE(std::holds_alternative<NumberGen>(alternation.alternatives[1]));
+        EXPECT_TRUE(std::holds_alternative<EmojiGen>(alternation.alternatives[2]));
+    }
+    // Surrounding text keeps a single alternation placeholder.
+    EXPECT_EQ(ParsePlaceholders("pre-{noun}|{verb}-post").size(), 1);
+}
+
+UTEST(PlaceholdersParser, AlternationToStringRoundTrip) {
+    EXPECT_EQ(ParsePattern("{noun}|{verb}").ToString(), "{noun}|{verb}");
+    EXPECT_EQ(ParsePattern("pre-{noun}|{verb}|{adjective}-post").ToString(), "pre-{noun}|{verb}|{adjective}-post");
+}
+
+UTEST(PlaceholdersParser, PipeReservedAndEscaped) {
+    // A bare unescaped pipe is reserved: valid only as an alternation operator between placeholders.
+    EXPECT_THROW(ParsePlaceholders("a|b"), PatternSyntaxError);
+    EXPECT_THROW(ParsePlaceholders("|{noun}"), PatternSyntaxError);
+    EXPECT_THROW(ParsePlaceholders("{noun}|"), PatternSyntaxError);
+    // An escaped pipe is literal text: it formats to a plain pipe, and ToString preserves the escape.
+    auto pattern = ParsePattern("a\\|b");
+    EXPECT_EQ(pattern.placeholders.size(), 0);
+    EXPECT_EQ(pattern.Format({}), "a|b");
+    EXPECT_EQ(pattern.ToString(), "a\\|b");
+}
+
 }  // namespace slugkit::generator


### PR DESCRIPTION
## What

Placeholder-level **alternation**: `{selector}|{selector}` chooses one of several child placeholders deterministically — "the same as case mutations." The pipe `|` becomes a reserved operator; a literal pipe is written `\|`.

```
{adverb}|{emoji}          -> an adverb OR an emoji
{noun}|{verb}|{adjective} -> one of three
pre-{noun}|{verb}-post    -> one alternation placeholder, with surrounding text
a\|b                      -> literal "a|b"
```

## How

**Grammar / parser**
- A run of pipe-separated placeholders (whitespace allowed around `|`) parses into a single `Alternation` element. An unescaped `|` anywhere else is a parse error with a hint to escape it.
- `\|` (and the other escapes) are now resolved to their literal character **at format time**; `ToString` keeps them verbatim so canonical output round-trips through the parser.
- Global settings (`[@lang +tag …]`) propagate into alternation children.

**Model / capacity**
- New `Pattern::Alternation` (a vector of simple placeholders — non-recursive, "placeholder alternation for now") added to the `PatternElement` variant.
- `AlternationSubstitutionGenerator`: **capacity = sum of the children's capacities**, max length = max. `Generate` permutes the sequence over the sum, selects a child block via cumulative caps, and passes the **in-block offset** as the child's sequence — so it's **collision-free** (each value in `[0, sum)` maps to a distinct `(child, output)`) and deterministic. This mirrors the existing variable-count emoji/special generators.
- Alternation children use the plain dictionary size (no prime/LCM maximization — a flat-composition heuristic) and are **not** stored in `PatternSettings::selectors`, so the settings format for alternation-free patterns is unchanged.

## Testing

Verified on host (in-memory + binary dictionaries):
- Capacity is the sum: `{noun}|{verb}` = 15, `{noun}|{verb}|{adjective}` = 22, `{adverb}|{emoji}` = 4773 (3619 + 1154).
- **Collision-free** over the capacity (all distinct), deterministic.
- `\|` renders as `|`; a bare `|` outside alternation is rejected.
- **Existing goldens intact** — `golden_test` 10/10, `c_abi_test` all pass.

Regression tests added: `pattern_test.cpp` (parsing, round-trip, escaping, errors), `generator_test.cpp` (capacity + collision-free), and host checks in `golden_test.cpp` / `c_abi_test.c`.

## Notes / open items

- Pattern **serialization stores only the pattern string** (re-parsed on load), so `io/` needs no changes.
- The **userver service build was not compiled here** (no userver in this env) — the core is standard C++ that builds clean under clang, and the variant visitors are all handled, but a devcontainer build is the final check.
- v1 scope is placeholder-level alternation (children are simple placeholders, not nested groups); nested/group alternation is a natural follow-up.