### PR TITLE
feat: collapse equivalent alternatives, reject overlapping ones

### DIFF
--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -182,6 +182,14 @@ int main(void) {
             /* A bare unescaped pipe is a parse error. */
             char* bar = slk_generate_alloc(mg, "a|b", "s", 0, &err);
             CHECK(bar == NULL, "unescaped `|` outside alternation is rejected");
+            /* Equivalent alternatives collapse: {adverb}|{adverb} has the capacity of one {adverb}. */
+            char* cc = NULL;
+            slk_capacity(mg, "{adverb}|{adverb}", &cc, NULL, &err);
+            CHECK(cc && strcmp(cc, "3619") == 0, "{adverb}|{adverb} collapses to capacity 3619");
+            slk_string_free(cc);
+            /* Overlapping alternatives ({adverb} is a superset of {adverb:+pos}) are a pattern error. */
+            char* ov = slk_generate_alloc(mg, "{adverb:+pos}|{adverb}", "s", 0, &err);
+            CHECK(ov == NULL, "overlapping alternatives (superset) are rejected");
 
             slk_generator_destroy(mg);
         }

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -5,6 +5,7 @@
 // / property-stable slug output without userver. The mixed-case section mirrors the property-based
 // form introduced by PR #20.
 
+#include <slugkit/generator/exceptions.hpp>
 #include <slugkit/generator/generator.hpp>
 #include <slugkit/generator/pattern_generator.hpp>
 #include <slugkit/utils/text.hpp>
@@ -202,6 +203,19 @@ TEST(PatternGenerator, Alternation) {
         seen.insert(slug);
     }
     EXPECT_EQ(seen.size(), kExpected.size());  // collision-free
+}
+
+// Equivalent alternatives (same predicate) collapse to one; alternatives whose outputs actually
+// intersect are a pattern error.
+TEST(PatternGenerator, AlternationCollapseAndDisjoint) {
+    auto dictionaries = MakeDictionarySet();
+    // {noun}|{noun} collapses -> capacity is 5, not 10 (no double counting, no collisions).
+    EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{noun}"_pattern_ptr).GetCapacity(), 5);
+    EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{noun}|{adjective}"_pattern_ptr).GetCapacity(), 12);
+    // {noun} is a superset of {noun:+tag1}, so their outputs overlap -> error.
+    EXPECT_THROW(PatternGenerator(dictionaries, "{noun:+tag1}|{noun}"_pattern_ptr), PatternSyntaxError);
+    // Disjoint dictionaries (noun* vs verb*) are fine.
+    EXPECT_NO_THROW(PatternGenerator(dictionaries, "{noun}|{verb}"_pattern_ptr));
 }
 
 // End-to-end generator: committed full-slug expectations from generator_test.cpp (GenerateID).

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -212,6 +212,12 @@ TEST(PatternGenerator, AlternationCollapseAndDisjoint) {
     // {noun}|{noun} collapses -> capacity is 5, not 10 (no double counting, no collisions).
     EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{noun}"_pattern_ptr).GetCapacity(), 5);
     EXPECT_EQ(PatternGenerator(dictionaries, "{noun}|{noun}|{adjective}"_pattern_ptr).GetCapacity(), 12);
+    // Collapse is type-agnostic: identical number/special generators collapse too.
+    EXPECT_EQ(PatternGenerator(dictionaries, "{number:2d}|{number:2d}"_pattern_ptr).GetCapacity(), 100);
+    // Distinct-but-disjoint number generators are kept ("00".."99" vs "000".."999" never coincide).
+    EXPECT_EQ(PatternGenerator(dictionaries, "{number:2d}|{number:3d}"_pattern_ptr).GetCapacity(), 1100);
+    // But decimal and hex 2-digit overlap (e.g. "27") -> error.
+    EXPECT_THROW(PatternGenerator(dictionaries, "{number:2d}|{number:2x}"_pattern_ptr), PatternSyntaxError);
     // {noun} is a superset of {noun:+tag1}, so their outputs overlap -> error.
     EXPECT_THROW(PatternGenerator(dictionaries, "{noun:+tag1}|{noun}"_pattern_ptr), PatternSyntaxError);
     // Disjoint dictionaries (noun* vs verb*) are fine.

--- a/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
+++ b/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
@@ -529,6 +529,12 @@ struct PatternParser {
         );
     }
 
+    // Hash of a simple placeholder over its full predicate (kind, tags, options, language, size
+    // limit, ...), used to detect equivalent alternatives.
+    static std::int64_t AlternativeHash(const Pattern::SimplePlaceholder& alternative) {
+        return std::visit([](auto&& arg) { return arg.GetHash(); }, alternative);
+    }
+
     Pattern::SimplePlaceholder ParseElement() {
         SkipWhitespace();
         if (IsEof()) {
@@ -627,7 +633,29 @@ struct PatternParser {
                         SkipWhitespace();
                     } while (Match(kAlternationChar));
                     pos_ = element_end;  // trailing whitespace after the last alternative is text
-                    result.push_back(Pattern::Alternation{std::move(alternatives)});
+                    // Collapse equivalent alternatives (same predicate incl. tags/options): they add
+                    // no variance and would otherwise double the capacity and let the same output
+                    // appear from more than one branch. Order is preserved (first occurrence wins).
+                    std::vector<Pattern::SimplePlaceholder> distinct;
+                    for (auto& alternative : alternatives) {
+                        auto hash = AlternativeHash(alternative);
+                        bool duplicate = false;
+                        for (const auto& kept : distinct) {
+                            if (kept.index() == alternative.index() && AlternativeHash(kept) == hash) {
+                                duplicate = true;
+                                break;
+                            }
+                        }
+                        if (!duplicate) {
+                            distinct.push_back(std::move(alternative));
+                        }
+                    }
+                    if (distinct.size() == 1) {
+                        // All alternatives were equivalent; it is a plain placeholder, not an alternation.
+                        result.push_back(ToPatternElement(std::move(distinct.front())));
+                    } else {
+                        result.push_back(Pattern::Alternation{std::move(distinct)});
+                    }
                 } else {
                     pos_ = element_end;  // no alternation; the skipped whitespace is arbitrary text
                     result.push_back(ToPatternElement(std::move(element)));

--- a/slugkit/src/slugkit/generator/pattern_generator.cpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <stdexcept>
+#include <unordered_map>
 
 namespace slugkit::generator {
 
@@ -436,13 +437,50 @@ auto BuildSimpleGenerator(const DictSet& dictionaries, const Pattern::SimplePlac
     return MakeEmojiGenerator(emoji_dict, emoji_gen);
 }
 
+// Final validation sweep for an alternation: the alternatives' output sets must be pairwise
+// disjoint, otherwise the alternation is not collision-free (two branches could produce the same
+// string -- e.g. a word that is both a noun and a verb, or `{adverb}` overlapping the subset
+// `{adverb:+pos}`). Enumerate each child's outputs and require no string appears twice. Children
+// whose output space is too large to enumerate (big number generators, large mixed-case selectors)
+// are skipped -- their outputs are effectively distinct in practice.
+void CheckAlternativesDisjoint(
+    const std::vector<SubstitutionGeneratorPtr>& children,
+    const Pattern::Alternation& alternation
+) {
+    constexpr std::uint64_t kMaxEnumerate = 100000;
+    auto describe = [&alternation](std::size_t index) {
+        return std::visit([](auto&& arg) { return "{" + arg.ToString() + "}"; }, alternation.alternatives[index]);
+    };
+    std::unordered_map<std::string, std::size_t> seen;
+    for (std::size_t i = 0; i < children.size(); ++i) {
+        if (children[i]->GetCapacity() > numeric::BigInt(kMaxEnumerate)) {
+            continue;
+        }
+        auto count = static_cast<std::uint64_t>(children[i]->GetCapacity());
+        for (std::uint64_t s = 0; s < count; ++s) {
+            auto [it, inserted] = seen.try_emplace(children[i]->Generate(0, s), i);
+            if (!inserted && it->second != i) {
+                throw PatternSyntaxError(fmt::format(
+                    "Alternation alternatives {} and {} overlap: both can produce `{}`",
+                    describe(it->second),
+                    describe(i),
+                    it->first
+                ));
+            }
+        }
+    }
+}
+
 template <typename DictSet>
-auto BuildAlternationGenerator(const DictSet& dictionaries, const Pattern::Alternation& alternation)
+auto BuildAlternationGenerator(const DictSet& dictionaries, const Pattern::Alternation& alternation, bool validate)
     -> SubstitutionGeneratorPtr {
     std::vector<SubstitutionGeneratorPtr> children;
     children.reserve(alternation.alternatives.size());
     for (const auto& alternative : alternation.alternatives) {
         children.push_back(BuildSimpleGenerator(dictionaries, alternative));
+    }
+    if (validate) {
+        CheckAlternativesDisjoint(children, alternation);
     }
     return std::make_unique<AlternationSubstitutionGenerator>(std::move(children));
 }
@@ -549,9 +587,11 @@ struct PatternGenerator::Impl {
                 }
                 generators.push_back(MakeEmojiGenerator(emoji_dict, emoji_gen));
             } else if (std::holds_alternative<Pattern::Alternation>(element)) {
-                generators.push_back(
-                    BuildAlternationGenerator(dictionaries, std::get<Pattern::Alternation>(element))
-                );
+                // Validation sweep: check the alternatives' outputs are disjoint (last, like the
+                // per-selector "no matching words" check).
+                generators.push_back(BuildAlternationGenerator(
+                    dictionaries, std::get<Pattern::Alternation>(element), /*validate=*/true
+                ));
             }
             capacity = lcm(capacity, generators.back()->GetCapacity());
             max_pattern_length += generators.back()->GetMaxLength();
@@ -594,9 +634,11 @@ struct PatternGenerator::Impl {
                 }
                 generators.push_back(MakeEmojiGenerator(emoji_dict, emoji_gen));
             } else if (std::holds_alternative<Pattern::Alternation>(element)) {
-                generators.push_back(
-                    BuildAlternationGenerator(dictionaries, std::get<Pattern::Alternation>(element))
-                );
+                // Loading stored settings: the pattern was already validated when the settings were
+                // computed, so skip the (costly) disjointness enumeration here.
+                generators.push_back(BuildAlternationGenerator(
+                    dictionaries, std::get<Pattern::Alternation>(element), /*validate=*/false
+                ));
             }
             capacity = lcm(capacity, generators.back()->GetCapacity());
             max_pattern_length += generators.back()->GetMaxLength();

--- a/slugkit/tests/generator_test.cpp
+++ b/slugkit/tests/generator_test.cpp
@@ -442,4 +442,15 @@ UTEST(PatternGenerator, Alternation) {
     EXPECT_EQ(seen.size(), kExpected.size());
 }
 
+UTEST(PatternGenerator, AlternationCollapseAndDisjoint) {
+    // Equivalent alternatives collapse -> no double counting.
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{noun}"_pattern_ptr).GetCapacity(), 5);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{noun}|{adjective}"_pattern_ptr).GetCapacity(), 12);
+    // Overlapping (non-equivalent) alternatives are a pattern error: {noun} is a superset of
+    // {noun:+tag1}, so their outputs intersect.
+    EXPECT_THROW(PatternGenerator(kDictionariesSet, "{noun:+tag1}|{noun}"_pattern_ptr), PatternSyntaxError);
+    // Disjoint dictionaries are fine (noun* vs verb* never coincide).
+    EXPECT_NO_THROW(PatternGenerator(kDictionariesSet, "{noun}|{verb}"_pattern_ptr));
+}
+
 }  // namespace slugkit::generator

--- a/slugkit/tests/generator_test.cpp
+++ b/slugkit/tests/generator_test.cpp
@@ -446,6 +446,11 @@ UTEST(PatternGenerator, AlternationCollapseAndDisjoint) {
     // Equivalent alternatives collapse -> no double counting.
     EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{noun}"_pattern_ptr).GetCapacity(), 5);
     EXPECT_EQ(PatternGenerator(kDictionariesSet, "{noun}|{noun}|{adjective}"_pattern_ptr).GetCapacity(), 12);
+    // Collapse is type-agnostic: identical number generators collapse; distinct disjoint ones are
+    // kept; overlapping ones (decimal vs hex 2-digit share e.g. "27") are an error.
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{number:2d}|{number:2d}"_pattern_ptr).GetCapacity(), 100);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "{number:2d}|{number:3d}"_pattern_ptr).GetCapacity(), 1100);
+    EXPECT_THROW(PatternGenerator(kDictionariesSet, "{number:2d}|{number:2x}"_pattern_ptr), PatternSyntaxError);
     // Overlapping (non-equivalent) alternatives are a pattern error: {noun} is a superset of
     // {noun:+tag1}, so their outputs intersect.
     EXPECT_THROW(PatternGenerator(kDictionariesSet, "{noun:+tag1}|{noun}"_pattern_ptr), PatternSyntaxError);

--- a/slugkit/tests/pattern_test.cpp
+++ b/slugkit/tests/pattern_test.cpp
@@ -674,4 +674,30 @@ UTEST(PlaceholdersParser, PipeReservedAndEscaped) {
     EXPECT_EQ(pattern.ToString(), "a\\|b");
 }
 
+UTEST(PlaceholdersParser, AlternationCollapsesEquivalentAlternatives) {
+    // Equivalent alternatives (same predicate) add no variance and collapse.
+    {
+        auto placeholders = ParsePlaceholders("{noun}|{noun}");
+        ASSERT_EQ(placeholders.size(), 1);
+        // Collapsed to a single selector -- not an alternation at all.
+        EXPECT_TRUE(std::holds_alternative<Selector>(placeholders[0]));
+    }
+    {
+        auto placeholders = ParsePlaceholders("{noun}|{noun}|{verb}");
+        ASSERT_EQ(placeholders.size(), 1);
+        ASSERT_TRUE(std::holds_alternative<Pattern::Alternation>(placeholders[0]));
+        // The duplicate noun is dropped, the verb kept.
+        EXPECT_EQ(std::get<Pattern::Alternation>(placeholders[0]).alternatives.size(), 2);
+    }
+    // Different tags are different predicates -> kept as distinct alternatives (mind the tags).
+    {
+        auto placeholders = ParsePlaceholders("{noun:+tag1}|{noun}");
+        ASSERT_EQ(placeholders.size(), 1);
+        ASSERT_TRUE(std::holds_alternative<Pattern::Alternation>(placeholders[0]));
+        EXPECT_EQ(std::get<Pattern::Alternation>(placeholders[0]).alternatives.size(), 2);
+    }
+    // The collapsed form is canonical.
+    EXPECT_EQ(ParsePattern("{noun}|{noun}").ToString(), "{noun}");
+}
+
 }  // namespace slugkit::generator


### PR DESCRIPTION
## What

Two follow-up refinements to placeholder alternation (`{a}|{b}`, merged in #29) so it stays genuinely collision-free.

### 1. Collapse equivalent alternatives
Alternatives with the **same predicate** (kind, tags, options, language, size limit — compared via `GetHash`) add no variance, so they're deduplicated at parse time (order preserved):
- `{noun}|{noun}` → a plain `{noun}` (capacity 5, not 10)
- `{noun}|{noun}|{verb}` → `{noun}|{verb}`
- Different tags are different predicates and are kept: `{noun:+tag1}|{noun}` stays two alternatives.

### 2. Reject alternatives whose outputs actually intersect
Distinct predicates can still produce the same string — a word that's both a noun and a verb, or a **superset** overlapping a subset:
- `{adverb}|{adverb:+pos}` → **error** (unfiltered ⊃ filtered)
- `{noun:+tag1}|{noun}` → **error** ({noun} ⊃ {noun:+tag1})
- `{noun}|{verb}`, `{adverb}|{emoji}` → **fine** (disjoint)

During the settings/validation sweep — the same place as the per-selector "no matching words" check — each child's output set is enumerated and required pairwise disjoint. An overlap raises `PatternSyntaxError` naming the two alternatives and a colliding output (e.g. *"Alternation alternatives {adverb:+pos} and {adverb} overlap: both can produce `abusively`"*). Children too large to enumerate (big number generators, large mixed-case selectors) are skipped. The check runs **only when computing settings**, not when reconstructing a generator from already-validated stored settings.

## Testing

Verified on host:
- Collapse: `{noun}|{noun}` = 5, `{adverb}|{adverb}` = 3619, `{noun}|{noun}|{adjective}` = 12.
- Reject: `{noun:+tag1}|{noun}` and `{adverb:+pos}|{adverb}` throw.
- Disjoint unaffected: `{noun}|{verb}` = 15, `{adverb}|{emoji}` = 4773.
- **golden_test 11/11, c_abi_test all pass**; existing goldens intact.

Regression tests added in `pattern_test.cpp` (collapse), `generator_test.cpp` (collapse + overlap error), and host checks in `golden_test.cpp` / `c_abi_test.c`.

## Notes

- Same as the alternation feature: the **userver service build wasn't compiled here** (no userver in this env); the core is standard C++ that builds clean under clang.