### PR TITLE
feat: group alternation `(...)|(...)` for locked tags

### DIFF
--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -191,6 +191,29 @@ int main(void) {
             char* ov = slk_generate_alloc(mg, "{adverb:+pos}|{adverb}", "s", 0, &err);
             CHECK(ov == NULL, "overlapping alternatives (superset) are rejected");
 
+            /* --- group alternation --- */
+            /* Pull-up: a lone group is transparent (same output as unparenthesised). */
+            char* pg = slk_generate_alloc(mg, "({adverb})", "s", 0, &err);
+            char* pp = slk_generate_alloc(mg, "{adverb}", "s", 0, &err);
+            CHECK(pg && pp && strcmp(pg, pp) == 0, "lone group `({adverb})` == `{adverb}`");
+            slk_string_free(pg);
+            slk_string_free(pp);
+            /* Escaped parens are literal. */
+            char* ep = slk_generate_alloc(mg, "a\\(b\\)c", "s", 0, &err);
+            CHECK(ep && strcmp(ep, "a(b)c") == 0, "escaped parens `a\\(b\\)c` -> `a(b)c`");
+            slk_string_free(ep);
+            /* Group alternation capacity = sum of branch LCMs: LCM(3619,1154)*2 = 8352652. */
+            char* gc = NULL;
+            slk_capacity(mg, "({adverb} {emoji})|({emoji} {adverb})", &gc, NULL, &err);
+            CHECK(gc && strcmp(gc, "8352652") == 0, "group alternation capacity is the sum of branch LCMs");
+            slk_string_free(gc);
+            /* Per-position overlap error: same second placeholder, first is a superset. */
+            char* go = slk_generate_alloc(mg, "({adverb:+pos} {emoji})|({adverb} {emoji})", "s", 0, &err);
+            CHECK(go == NULL, "overlapping group branches are rejected (per-position)");
+            /* Empty group is rejected. */
+            char* eg = slk_generate_alloc(mg, "()", "s", 0, &err);
+            CHECK(eg == NULL, "empty group `()` is rejected");
+
             slk_generator_destroy(mg);
         }
     }

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -224,6 +224,41 @@ TEST(PatternGenerator, AlternationCollapseAndDisjoint) {
     EXPECT_NO_THROW(PatternGenerator(dictionaries, "{noun}|{verb}"_pattern_ptr));
 }
 
+// Group alternation: parenthesised branches lock correlated choices; lone/collapsed groups pull up.
+TEST(PatternGenerator, GroupAlternation) {
+    auto dictionaries = MakeDictionarySet();
+    auto seed_hash = PatternGenerator::SeedHash(kTestSeed);
+
+    // Pull-up: a lone group is transparent -- same capacity AND same output as unparenthesised.
+    EXPECT_EQ(PatternGenerator(dictionaries, "({noun})"_pattern_ptr).GetCapacity(), 5);
+    EXPECT_EQ(PatternGenerator(dictionaries, "({adjective} {noun})"_pattern_ptr).GetCapacity(), 35);
+    EXPECT_EQ(PatternGenerator(dictionaries, "pre-({adjective} {noun})-post"_pattern_ptr).GetCapacity(), 35);
+    {
+        PatternGenerator grouped(dictionaries, "({adjective} {noun})"_pattern_ptr);
+        PatternGenerator plain(dictionaries, "{adjective} {noun}"_pattern_ptr);
+        for (std::uint64_t i = 0; i < 20; ++i) {
+            EXPECT_EQ(grouped(seed_hash, i), plain(seed_hash, i)) << "i=" << i;  // pull-up is exact
+        }
+    }
+
+    // Group alternation capacity is the sum of the branches' LCMs.
+    // LCM(noun=5, verb=10)=10; LCM(adjective=7, adverb=9)=63; total 73.
+    EXPECT_EQ(
+        PatternGenerator(dictionaries, "({noun} {verb})|({adjective} {adverb})"_pattern_ptr).GetCapacity(), 73
+    );
+    // Text-only branches.
+    EXPECT_EQ(PatternGenerator(dictionaries, "(foo)|(bar)"_pattern_ptr).GetCapacity(), 2);
+
+    // Disjoint branches are fine (noun*/verb* vs adjective*/adverb* never coincide).
+    EXPECT_NO_THROW(PatternGenerator(dictionaries, "({noun} {verb})|({adjective} {adverb})"_pattern_ptr));
+    // Overlap is a pattern error: at every aligned position the branches can coincide
+    // ({noun:+tag1} is a subset of {noun}; the second placeholder is identical).
+    EXPECT_THROW(
+        PatternGenerator(dictionaries, "({noun:+tag1} {adjective})|({noun} {adjective})"_pattern_ptr),
+        PatternSyntaxError
+    );
+}
+
 // End-to-end generator: committed full-slug expectations from generator_test.cpp (GenerateID).
 TEST(Generator, GenerateID) {
     Generator generator(MakeDictionarySet());

--- a/slugkit/include/slugkit/generator/pattern.hpp
+++ b/slugkit/include/slugkit/generator/pattern.hpp
@@ -30,15 +30,32 @@ struct Pattern {
     /// @brief A single (non-alternating) placeholder.
     using SimplePlaceholder = std::variant<Selector, NumberGen, SpecialCharGen, EmojiGen>;
 
-    /// @brief An alternation chooses one of several child placeholders deterministically, the same
-    /// way case mutations pick a cased form: its capacity is the sum of the children's capacities,
-    /// and a sequence value selects a child block and the offset within it.
-    /// @note Placeholder-level alternation only for now: the children are simple placeholders, not
-    /// nested alternations.
-    struct Alternation {
-        std::vector<SimplePlaceholder> alternatives;
+    /// @brief Owned literal-text chunks interleaved with placeholders. Owned (not string_view) so
+    /// that pulling up a lone/collapsed group can concatenate boundary text (see the group proposal).
+    using TextChunks = std::vector<std::string>;
 
-        /// @brief Canonical, re-parseable representation, e.g. "{noun}|{verb}".
+    /// @brief A flat sub-pattern: literal text interleaved with simple placeholders. Used as an
+    /// alternation branch (`(...)`). Invariant: text_chunks.size() == placeholders.size() + 1.
+    /// @note Flat for now: a group contains simple placeholders, not nested groups/alternations.
+    struct Group {
+        TextChunks text_chunks;
+        std::vector<SimplePlaceholder> placeholders;
+
+        /// @brief Canonical, re-parseable representation of the group's contents, e.g. "{adj} {noun}".
+        [[nodiscard]] auto ToString() const -> std::string;
+        [[nodiscard]] auto GetHash() const -> std::int64_t;
+        [[nodiscard]] auto Complexity() const -> std::int32_t;
+        [[nodiscard]] auto IsNSFW() const -> bool;
+    };
+
+    /// @brief An alternation chooses one of several branch groups deterministically, the same way
+    /// case mutations pick a cased form: its capacity is the sum of the branches' capacities, and a
+    /// sequence value selects a branch block and the offset within it.
+    /// @note An alternation always has >= 2 distinct branches; a single branch is pulled up.
+    struct Alternation {
+        std::vector<Group> alternatives;
+
+        /// @brief Canonical, re-parseable representation, e.g. "({a} {b})|{c}".
         [[nodiscard]] auto ToString() const -> std::string;
         [[nodiscard]] auto GetHash() const -> std::int64_t;
         [[nodiscard]] auto Complexity() const -> std::int32_t;
@@ -47,7 +64,6 @@ struct Pattern {
 
     using PatternElement = std::variant<Selector, NumberGen, SpecialCharGen, EmojiGen, Alternation>;
     using Placeholders = std::vector<PatternElement>;
-    using TextChunks = std::vector<std::string_view>;
     using Substitutions = std::vector<std::string>;
 
     const std::string pattern;
@@ -100,6 +116,14 @@ struct Pattern {
 auto ParsePlaceholders(std::string_view pattern) -> Pattern::Placeholders;
 
 auto ParsePattern(std::string_view pattern) -> Pattern;
+
+/// @brief Interleave literal text chunks with substitutions (text, sub, text, ..., text).
+/// Shared by SlugFormatter and the group substitution generator.
+/// @param unescape_text When true, backslash escapes in the text are resolved to their literal
+/// character (generation); when false the text is emitted verbatim (canonical ToString).
+/// @note Requires text_chunks.size() == substitutions.size() + 1.
+auto FormatChunks(const Pattern::TextChunks& text_chunks, const Pattern::Substitutions& substitutions,
+                  bool unescape_text = true) -> std::string;
 
 using PatternPtr = std::shared_ptr<Pattern>;
 

--- a/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
+++ b/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
@@ -67,10 +67,12 @@ struct PatternParser {
                 selector.language = language;
             }
         }
-        // Global settings propagate into alternation children (which are simple placeholders).
+        // Global settings propagate into alternation branches' placeholders.
         void operator()(Pattern::Alternation& alternation) const {
-            for (auto& child : alternation.alternatives) {
-                std::visit(*this, child);
+            for (auto& group : alternation.alternatives) {
+                for (auto& placeholder : group.placeholders) {
+                    std::visit(*this, placeholder);
+                }
             }
         }
         void operator()(auto&&) const {
@@ -84,10 +86,12 @@ struct PatternParser {
                 selector.include_tags.insert(tag);
             }
         }
-        // Global settings propagate into alternation children (which are simple placeholders).
+        // Global settings propagate into alternation branches' placeholders.
         void operator()(Pattern::Alternation& alternation) const {
-            for (auto& child : alternation.alternatives) {
-                std::visit(*this, child);
+            for (auto& group : alternation.alternatives) {
+                for (auto& placeholder : group.placeholders) {
+                    std::visit(*this, placeholder);
+                }
             }
         }
         void operator()(auto&&) const {
@@ -101,10 +105,12 @@ struct PatternParser {
                 selector.exclude_tags.insert(tag);
             }
         }
-        // Global settings propagate into alternation children (which are simple placeholders).
+        // Global settings propagate into alternation branches' placeholders.
         void operator()(Pattern::Alternation& alternation) const {
-            for (auto& child : alternation.alternatives) {
-                std::visit(*this, child);
+            for (auto& group : alternation.alternatives) {
+                for (auto& placeholder : group.placeholders) {
+                    std::visit(*this, placeholder);
+                }
             }
         }
         void operator()(auto&&) const {
@@ -118,10 +124,12 @@ struct PatternParser {
                 selector.size_limit = size_limit;
             }
         }
-        // Global settings propagate into alternation children (which are simple placeholders).
+        // Global settings propagate into alternation branches' placeholders.
         void operator()(Pattern::Alternation& alternation) const {
-            for (auto& child : alternation.alternatives) {
-                std::visit(*this, child);
+            for (auto& group : alternation.alternatives) {
+                for (auto& placeholder : group.placeholders) {
+                    std::visit(*this, placeholder);
+                }
             }
         }
         void operator()(auto&&) const {
@@ -132,7 +140,9 @@ struct PatternParser {
 
     constexpr static char kEscapeChar = '\\';
     constexpr static char kAlternationChar = '|';
-    constexpr static std::string_view kEscapedChars = "\\{}[]|";
+    constexpr static char kGroupOpen = '(';
+    constexpr static char kGroupClose = ')';
+    constexpr static std::string_view kEscapedChars = "\\{}[]|()";
     constexpr static std::string_view kNumberKeyword = "number";
     constexpr static std::string_view kNumKeword = "num";
     constexpr static std::string_view kSpecialCharKeyword = "special";
@@ -211,7 +221,8 @@ struct PatternParser {
     }
 
     bool IsArbitraryText(char c) const {
-        return c != '{' && c != '}' && c != '[' && c != ']' && c != kEscapeChar && c != kAlternationChar;
+        return c != '{' && c != '}' && c != '[' && c != ']' && c != kEscapeChar && c != kAlternationChar &&
+               c != kGroupOpen && c != kGroupClose;
     }
 
     void SkipArbitraryText() {
@@ -529,10 +540,86 @@ struct PatternParser {
         );
     }
 
-    // Hash of a simple placeholder over its full predicate (kind, tags, options, language, size
-    // limit, ...), used to detect equivalent alternatives.
-    static std::int64_t AlternativeHash(const Pattern::SimplePlaceholder& alternative) {
-        return std::visit([](auto&& arg) { return arg.GetHash(); }, alternative);
+    // Consume arbitrary text (and escapes) into `pending`, keeping escapes raw so the canonical form
+    // round-trips and generation un-escapes. Stops at any reserved character.
+    void AccumulateText(std::string& pending) {
+        while (!IsEof()) {
+            char c = Peek();
+            if (IsArbitraryText(c)) {
+                pending.push_back(c);
+                Next();
+                continue;
+            }
+            if (c != kEscapeChar) {
+                break;  // a reserved char handled by the caller
+            }
+            Next();  // consume '\'
+            if (IsEof()) {
+                throw PatternSyntaxError(
+                    fmt::format("Pattern parse error: unexpected end of pattern at column {}", GetCurrentColumn())
+                );
+            }
+            char escaped = Peek();
+            if (kEscapedChars.find(escaped) == std::string_view::npos) {
+                throw PatternSyntaxError(
+                    fmt::format("Pattern parse error: invalid escape `\\{}` at column {}", escaped, GetCurrentColumn())
+                );
+            }
+            pending.push_back(kEscapeChar);  // keep raw; FormatChunks un-escapes at generation time
+            pending.push_back(escaped);
+            Next();
+        }
+    }
+
+    // Parse a group body (between '(' and ')'): text interleaved with placeholders. Flat -- no nested
+    // groups/alternations; `(`, `|`, `[`, `]` inside must be escaped. Does not consume the ')'.
+    Pattern::Group ParseGroupBody() {
+        Pattern::Group group;
+        std::string pending;
+        while (true) {
+            AccumulateText(pending);
+            if (IsEof() || Match(kGroupClose)) {
+                break;
+            }
+            if (Match('{')) {
+                Next();
+                group.text_chunks.push_back(std::move(pending));
+                pending.clear();
+                group.placeholders.push_back(ParseElement());
+                Expect('}');
+            } else {
+                throw PatternSyntaxError(fmt::format(
+                    "Pattern parse error: unexpected `{}` inside group at column {}; escape it for a literal",
+                    Peek(),
+                    GetCurrentColumn()
+                ));
+            }
+        }
+        group.text_chunks.push_back(std::move(pending));  // trailing text; text.size() == ph.size() + 1
+        return group;
+    }
+
+    // Parse one alternation branch: a parenthesised group `( ... )`, or a bare placeholder `{ ... }`
+    // wrapped as a single-placeholder group with no surrounding text.
+    Pattern::Group ParseAlternationElement() {
+        if (Match(kGroupOpen)) {
+            Next();  // consume '('
+            auto group = ParseGroupBody();
+            Expect(kGroupClose);
+            if (group.placeholders.empty() && group.text_chunks.size() == 1 && group.text_chunks[0].empty()) {
+                throw PatternSyntaxError(
+                    fmt::format("Pattern parse error: empty group `()` at column {}", GetCurrentColumn())
+                );
+            }
+            return group;
+        }
+        Expect('{');
+        Pattern::Group group;
+        group.text_chunks.emplace_back();  // leading ""
+        group.placeholders.push_back(ParseElement());
+        Expect('}');
+        group.text_chunks.emplace_back();  // trailing ""
+        return group;
     }
 
     Pattern::SimplePlaceholder ParseElement() {
@@ -600,94 +687,89 @@ struct PatternParser {
 
     Pattern::Placeholders operator()(Pattern::TextChunks& text_chunks) {
         Pattern::Placeholders result;
-        auto arbitrary_start = pos_;
-        auto arbitrary_text_end = pattern_.end();
+        std::string pending;  // arbitrary text (raw, escapes kept) awaiting the next element
+
+        // Push an element (placeholder or alternation) preceded by the accumulated pending text.
+        // Keeps text_chunks.size() == result.size() until the trailing chunk is pushed at EOF.
+        auto push_element = [&](Pattern::PatternElement&& element) {
+            text_chunks.push_back(pending);
+            pending.clear();
+            result.push_back(std::move(element));
+        };
+        // Pull a group up into the enclosing pattern: parentheses are transparent, so the group's
+        // text and placeholders are inlined, boundary text merging with `pending`. Exact equivalence
+        // to writing the group's contents unparenthesised.
+        auto pull_up = [&](Pattern::Group&& group) {
+            pending += group.text_chunks.front();
+            for (std::size_t i = 0; i < group.placeholders.size(); ++i) {
+                text_chunks.push_back(pending);
+                pending = group.text_chunks[i + 1];
+                result.push_back(ToPatternElement(std::move(group.placeholders[i])));
+            }
+        };
+
         while (!IsEof()) {
-            SkipArbitraryText();
+            AccumulateText(pending);
             if (IsEof()) {
-                text_chunks.push_back(std::string_view(arbitrary_start, pos_));
                 break;
             }
-            if (Match('{')) {
-                // We push arbitrary text before the placeholder to the text chunks.
-                // Empty text chunks are also pushed.
-                // Postcondition: text_chunks.size() == result.size() + 1.
-                text_chunks.push_back(std::string_view(arbitrary_start, pos_));
-                Next();
-                auto element = ParseElement();
-                Expect('}');
-                // Alternation: `{a}|{b}|...` (whitespace allowed around `|`). A run of pipe-separated
-                // placeholders becomes a single Alternation element.
-                auto element_end = pos_;
+            if (Match('{') || Match(kGroupOpen)) {
+                // Alternation run: `elem (| elem)*`, each branch a group `(...)` or bare placeholder.
+                std::vector<Pattern::Group> branches;
+                branches.push_back(ParseAlternationElement());
+                auto run_end = pos_;
                 SkipWhitespace();
-                if (Match(kAlternationChar)) {
-                    std::vector<Pattern::SimplePlaceholder> alternatives;
-                    alternatives.push_back(std::move(element));
-                    do {
-                        Next();  // consume '|'
-                        SkipWhitespace();
-                        Expect('{');
-                        alternatives.push_back(ParseElement());
-                        Expect('}');
-                        element_end = pos_;
-                        SkipWhitespace();
-                    } while (Match(kAlternationChar));
-                    pos_ = element_end;  // trailing whitespace after the last alternative is text
-                    // Collapse equivalent alternatives (same predicate incl. tags/options): they add
-                    // no variance and would otherwise double the capacity and let the same output
-                    // appear from more than one branch. Order is preserved (first occurrence wins).
-                    std::vector<Pattern::SimplePlaceholder> distinct;
-                    for (auto& alternative : alternatives) {
-                        auto hash = AlternativeHash(alternative);
-                        bool duplicate = false;
-                        for (const auto& kept : distinct) {
-                            if (kept.index() == alternative.index() && AlternativeHash(kept) == hash) {
-                                duplicate = true;
-                                break;
-                            }
-                        }
-                        if (!duplicate) {
-                            distinct.push_back(std::move(alternative));
-                        }
-                    }
-                    if (distinct.size() == 1) {
-                        // All alternatives were equivalent; it is a plain placeholder, not an alternation.
-                        result.push_back(ToPatternElement(std::move(distinct.front())));
-                    } else {
-                        result.push_back(Pattern::Alternation{std::move(distinct)});
-                    }
-                } else {
-                    pos_ = element_end;  // no alternation; the skipped whitespace is arbitrary text
-                    result.push_back(ToPatternElement(std::move(element)));
+                while (Match(kAlternationChar)) {
+                    Next();  // consume '|'
+                    SkipWhitespace();
+                    branches.push_back(ParseAlternationElement());
+                    run_end = pos_;
+                    SkipWhitespace();
                 }
-                arbitrary_start = pos_;
+                pos_ = run_end;  // trailing whitespace after the run is arbitrary text
+
+                // Collapse equivalent branches (same text + same placeholder predicates, via
+                // Group::GetHash): they add no variance. Order preserved (first occurrence wins).
+                std::vector<Pattern::Group> distinct;
+                for (auto& branch : branches) {
+                    auto hash = branch.GetHash();
+                    bool duplicate = false;
+                    for (const auto& kept : distinct) {
+                        if (kept.GetHash() == hash) {
+                            duplicate = true;
+                            break;
+                        }
+                    }
+                    if (!duplicate) {
+                        distinct.push_back(std::move(branch));
+                    }
+                }
+
+                if (distinct.size() == 1) {
+                    // Lone group / all-equivalent alternation: pull up (parentheses are transparent).
+                    pull_up(std::move(distinct.front()));
+                } else {
+                    push_element(Pattern::Alternation{std::move(distinct)});
+                }
             } else if (Match('[')) {
-                arbitrary_text_end = pos_;
                 Next();
                 ParseGlobalSettings(result);
                 Expect(']');
                 SkipWhitespace();
-                // Expect EOF
                 if (!IsEof()) {
                     throw PatternSyntaxError(
                         fmt::format("Pattern parse error: unexpected character at column {}", GetCurrentColumn())
                     );
                 }
-            } else if (Match(kEscapeChar)) {
-                Next();
-                if (IsEof()) {
-                    throw PatternSyntaxError(
-                        fmt::format("Pattern parse error: unexpected end of pattern at column {}", GetCurrentColumn())
-                    );
-                }
-                ExpectOneOf(kEscapedChars);
-                // The escape (backslash + char) stays in the arbitrary-text run and is resolved at
-                // format time (SlugFormatter un-escapes `\X` -> `X`).
             } else if (Match(kAlternationChar)) {
                 throw PatternSyntaxError(fmt::format(
                     "Pattern parse error: unexpected `|` at column {}; alternation must be between "
-                    "placeholders (`{{a}}|{{b}}`); escape as `\\|` for a literal pipe",
+                    "placeholders or groups; escape as `\\|` for a literal pipe",
                     GetCurrentColumn()
+                ));
+            } else if (Match(kGroupClose)) {
+                throw PatternSyntaxError(fmt::format(
+                    "Pattern parse error: unmatched `)` at column {}; escape as `\\)` for a literal", GetCurrentColumn()
                 ));
             } else {
                 throw PatternSyntaxError(
@@ -695,9 +777,7 @@ struct PatternParser {
                 );
             }
         }
-        if (text_chunks.size() == result.size()) {
-            text_chunks.push_back(std::string_view(arbitrary_start, arbitrary_text_end));
-        }
+        text_chunks.push_back(std::move(pending));  // final chunk; text_chunks.size()==result.size()+1
         return result;
     }
 };

--- a/slugkit/src/slugkit/generator/pattern.cpp
+++ b/slugkit/src/slugkit/generator/pattern.cpp
@@ -37,38 +37,88 @@ std::string Pattern::ToString() const {
     return SlugFormatter(*this, /*unescape_text=*/false)(substitutions);
 }
 
+std::string Pattern::Group::ToString() const {
+    // Canonical inner content: text and placeholders interleaved. Text is kept verbatim (escapes
+    // preserved so it re-parses); each placeholder is wrapped in braces.
+    std::string result;
+    for (std::size_t i = 0; i < placeholders.size(); ++i) {
+        result += text_chunks[i];
+        std::visit([&result](auto&& arg) { result += fmt::format("{{{}}}", arg.ToString()); }, placeholders[i]);
+    }
+    result += text_chunks.back();
+    return result;
+}
+
+std::int64_t Pattern::Group::GetHash() const {
+    std::size_t seed = 0;
+    for (const auto& chunk : text_chunks) {
+        boost::hash_combine(seed, FNV1aHash(chunk));
+    }
+    for (const auto& placeholder : placeholders) {
+        std::visit([&seed](auto&& arg) { boost::hash_combine(seed, arg.GetHash()); }, placeholder);
+    }
+    return seed;
+}
+
+std::int32_t Pattern::Group::Complexity() const {
+    std::int32_t cost = 0;
+    for (const auto& placeholder : placeholders) {
+        std::visit([&cost](auto&& arg) { cost += arg.Complexity(); }, placeholder);
+    }
+    return cost;
+}
+
+bool Pattern::Group::IsNSFW() const {
+    for (const auto& placeholder : placeholders) {
+        if (std::holds_alternative<Selector>(placeholder) && std::get<Selector>(placeholder).IsNSFW()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::string Pattern::Alternation::ToString() const {
     std::string result;
     bool first = true;
-    for (const auto& alt : alternatives) {
+    for (const auto& branch : alternatives) {
         if (!first) {
             result += '|';
         }
         first = false;
-        std::visit([&result](auto&& arg) { result += fmt::format("{{{}}}", arg.ToString()); }, alt);
+        // A single bare placeholder renders without parentheses ({noun}); anything else (multiple
+        // placeholders, or literal text around them) is parenthesised.
+        const bool bare = branch.placeholders.size() == 1 && branch.text_chunks[0].empty() &&
+                          branch.text_chunks[1].empty();
+        if (bare) {
+            result += branch.ToString();
+        } else {
+            result += '(';
+            result += branch.ToString();
+            result += ')';
+        }
     }
     return result;
 }
 
 std::int64_t Pattern::Alternation::GetHash() const {
     std::size_t seed = 0;
-    for (const auto& alt : alternatives) {
-        std::visit([&seed](auto&& arg) { boost::hash_combine(seed, arg.GetHash()); }, alt);
+    for (const auto& branch : alternatives) {
+        boost::hash_combine(seed, branch.GetHash());
     }
     return seed;
 }
 
 std::int32_t Pattern::Alternation::Complexity() const {
     std::int32_t cost = 0;
-    for (const auto& alt : alternatives) {
-        std::visit([&cost](auto&& arg) { cost += arg.Complexity(); }, alt);
+    for (const auto& branch : alternatives) {
+        cost += branch.Complexity();
     }
     return cost;
 }
 
 bool Pattern::Alternation::IsNSFW() const {
-    for (const auto& alt : alternatives) {
-        if (std::holds_alternative<Selector>(alt) && std::get<Selector>(alt).IsNSFW()) {
+    for (const auto& branch : alternatives) {
+        if (branch.IsNSFW()) {
             return true;
         }
     }
@@ -157,6 +207,27 @@ void AppendText(std::string& result, std::string_view chunk, bool unescape) {
 
 }  // namespace
 
+std::string FormatChunks(const Pattern::TextChunks& text_chunks, const Pattern::Substitutions& substitutions,
+                         bool unescape_text) {
+    // Invariant: text_chunks.size() == substitutions.size() + 1. Shared by SlugFormatter (whole
+    // pattern) and the group substitution generator (a group's sub-pattern).
+    std::size_t reserve = 0;
+    for (const auto& chunk : text_chunks) {
+        reserve += chunk.size();
+    }
+    for (const auto& substitution : substitutions) {
+        reserve += substitution.size();
+    }
+    std::string result;
+    result.reserve(reserve);
+    for (std::size_t i = 0; i < substitutions.size(); ++i) {
+        AppendText(result, text_chunks[i], unescape_text);
+        result += substitutions[i];
+    }
+    AppendText(result, text_chunks.back(), unescape_text);
+    return result;
+}
+
 SlugFormatter::SlugFormatter(const Pattern& pattern, bool unescape_text)
     : pattern_(pattern)
     , unescape_text_(unescape_text) {
@@ -168,30 +239,7 @@ std::string SlugFormatter::operator()(Substitutions substitutions) const {
             fmt::format("Expected {} substitutions, got {}", pattern_.placeholders.size(), substitutions.size())
         );
     }
-
-    auto subsitutions_length = std::accumulate(
-        substitutions.begin(),
-        substitutions.end(),
-        std::size_t(0),
-        [](std::size_t sum, const std::string& substitution) { return sum + substitution.size(); }
-    );
-    auto arbitrary_text_length = pattern_.ArbitraryTextLength();
-
-    std::string result;
-    result.reserve(arbitrary_text_length + subsitutions_length);
-
-    auto text_chunk_iter = pattern_.text_chunks.begin();
-    auto substitution_iter = substitutions.begin();
-
-    while (substitution_iter != substitutions.end()) {
-        AppendText(result, *text_chunk_iter, unescape_text_);
-        text_chunk_iter++;
-        result.append(*substitution_iter);
-        substitution_iter++;
-    }
-    AppendText(result, *text_chunk_iter, unescape_text_);
-
-    return result;
+    return FormatChunks(pattern_.text_chunks, substitutions, unescape_text_);
 }
 
 namespace literals {

--- a/slugkit/src/slugkit/generator/pattern_generator.cpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.cpp
@@ -8,8 +8,9 @@
 #include <slugkit/utils/text.hpp>
 
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
-#include <unordered_map>
+#include <unordered_set>
 
 namespace slugkit::generator {
 
@@ -362,6 +363,39 @@ std::string AlternationSubstitutionGenerator::Generate(std::uint32_t seed, std::
 }
 
 //-------------------------------------------------------------
+// GroupSubstitutionGenerator
+//-------------------------------------------------------------
+GroupSubstitutionGenerator::GroupSubstitutionGenerator(
+    std::vector<SubstitutionGeneratorPtr> generators,
+    Pattern::TextChunks text_chunks
+)
+    : generators_{std::move(generators)}
+    , text_chunks_{std::move(text_chunks)}
+    , capacity_{1}
+    , max_length_{0} {
+    for (const auto& chunk : text_chunks_) {
+        max_length_ += chunk.size();
+    }
+    for (const auto& generator : generators_) {
+        // Placeholders inside a group compose like the top-level pattern: LCM capacity.
+        capacity_ = lcm(capacity_, generator->GetCapacity());
+        max_length_ += generator->GetMaxLength();
+    }
+}
+
+std::string GroupSubstitutionGenerator::Generate(std::uint32_t seed, std::size_t sequence_number) const {
+    // Same composition as PatternGenerator::Impl::Generate: seed-step each placeholder, format with
+    // the group's own text chunks (un-escaping literal escapes at generation time).
+    std::vector<std::string> substitutions;
+    substitutions.reserve(generators_.size());
+    for (const auto& generator : generators_) {
+        seed += kSeedStep;
+        substitutions.push_back(generator->Generate(seed, sequence_number));
+    }
+    return FormatChunks(text_chunks_, substitutions, /*unescape_text=*/true);
+}
+
+//-------------------------------------------------------------
 // PatternGenerator::Impl
 //-------------------------------------------------------------
 namespace {
@@ -437,34 +471,120 @@ auto BuildSimpleGenerator(const DictSet& dictionaries, const Pattern::SimplePlac
     return MakeEmojiGenerator(emoji_dict, emoji_gen);
 }
 
-// Final validation sweep for an alternation: the alternatives' output sets must be pairwise
-// disjoint, otherwise the alternation is not collision-free (two branches could produce the same
-// string -- e.g. a word that is both a noun and a verb, or `{adverb}` overlapping the subset
-// `{adverb:+pos}`). Enumerate each child's outputs and require no string appears twice. Children
-// whose output space is too large to enumerate (big number generators, large mixed-case selectors)
-// are skipped -- their outputs are effectively distinct in practice.
+// Enumerate a generator's full output set, or nullopt if it is too large to enumerate.
+auto EnumerateOutputs(const SubstitutionGenerator& generator) -> std::optional<std::unordered_set<std::string>> {
+    constexpr std::uint64_t kMaxEnumerate = 100000;
+    if (generator.GetCapacity() > numeric::BigInt(kMaxEnumerate)) {
+        return std::nullopt;
+    }
+    auto count = static_cast<std::uint64_t>(generator.GetCapacity());
+    std::unordered_set<std::string> outputs;
+    outputs.reserve(count);
+    for (std::uint64_t s = 0; s < count; ++s) {
+        outputs.insert(generator.Generate(0, s));
+    }
+    return outputs;
+}
+
+bool SetsOverlap(const std::unordered_set<std::string>& a, const std::unordered_set<std::string>& b) {
+    const auto& small = a.size() <= b.size() ? a : b;
+    const auto& large = a.size() <= b.size() ? b : a;
+    for (const auto& value : small) {
+        if (large.count(value) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+enum class Disjointness { kDisjoint, kOverlap, kUnknown };
+
+// Do two placeholders' output sets overlap? kUnknown if either is too large to enumerate.
+template <typename DictSet>
+auto PlaceholderDisjointness(
+    const DictSet& dictionaries,
+    const Pattern::SimplePlaceholder& a,
+    const Pattern::SimplePlaceholder& b
+) -> Disjointness {
+    auto set_a = EnumerateOutputs(*BuildSimpleGenerator(dictionaries, a));
+    auto set_b = EnumerateOutputs(*BuildSimpleGenerator(dictionaries, b));
+    if (!set_a || !set_b) {
+        return Disjointness::kUnknown;
+    }
+    return SetsOverlap(*set_a, *set_b) ? Disjointness::kOverlap : Disjointness::kDisjoint;
+}
+
+std::string UnescapeChunk(const std::string& chunk) {
+    std::string result;
+    for (std::size_t i = 0; i < chunk.size(); ++i) {
+        if (chunk[i] == '\\' && i + 1 < chunk.size()) {
+            result.push_back(chunk[++i]);
+        } else {
+            result.push_back(chunk[i]);
+        }
+    }
+    return result;
+}
+
+// Can two branch groups produce the same slug? Same-shape branches use the per-position refinement
+// (a product of positions is empty iff any factor is empty), which only enumerates each placeholder
+// (cheap) rather than the whole cross-product. Different-shape branches fall back to bounded
+// full-output enumeration. Pairs that are too large to decide are treated as non-overlapping.
+template <typename DictSet>
+bool GroupsOverlap(
+    const DictSet& dictionaries,
+    const Pattern::Group& g1,
+    const SubstitutionGenerator& gen1,
+    const Pattern::Group& g2,
+    const SubstitutionGenerator& gen2
+) {
+    if (g1.placeholders.size() == g2.placeholders.size()) {
+        for (std::size_t k = 0; k < g1.text_chunks.size(); ++k) {
+            if (UnescapeChunk(g1.text_chunks[k]) != UnescapeChunk(g2.text_chunks[k])) {
+                return false;  // differing literal text separates the branches
+            }
+        }
+        bool any_unknown = false;
+        for (std::size_t i = 0; i < g1.placeholders.size(); ++i) {
+            switch (PlaceholderDisjointness(dictionaries, g1.placeholders[i], g2.placeholders[i])) {
+                case Disjointness::kDisjoint:
+                    return false;  // this position separates the branches
+                case Disjointness::kUnknown:
+                    any_unknown = true;
+                    break;
+                case Disjointness::kOverlap:
+                    break;
+            }
+        }
+        return !any_unknown;  // all positions overlap (text equal) -> overlap; unknown -> best-effort allow
+    }
+    // Different shape: bounded full-output enumeration.
+    auto set1 = EnumerateOutputs(gen1);
+    auto set2 = EnumerateOutputs(gen2);
+    if (!set1 || !set2) {
+        return false;
+    }
+    return SetsOverlap(*set1, *set2);
+}
+
+// Validation sweep: alternation branches must be pairwise disjoint, else the alternation is not
+// collision-free (two branches producing the same slug -- a word that is both a noun and a verb, or
+// a superset like `{adverb}` overlapping `{adverb:+pos}`).
+template <typename DictSet>
 void CheckAlternativesDisjoint(
+    const DictSet& dictionaries,
     const std::vector<SubstitutionGeneratorPtr>& children,
     const Pattern::Alternation& alternation
 ) {
-    constexpr std::uint64_t kMaxEnumerate = 100000;
-    auto describe = [&alternation](std::size_t index) {
-        return std::visit([](auto&& arg) { return "{" + arg.ToString() + "}"; }, alternation.alternatives[index]);
-    };
-    std::unordered_map<std::string, std::size_t> seen;
-    for (std::size_t i = 0; i < children.size(); ++i) {
-        if (children[i]->GetCapacity() > numeric::BigInt(kMaxEnumerate)) {
-            continue;
-        }
-        auto count = static_cast<std::uint64_t>(children[i]->GetCapacity());
-        for (std::uint64_t s = 0; s < count; ++s) {
-            auto [it, inserted] = seen.try_emplace(children[i]->Generate(0, s), i);
-            if (!inserted && it->second != i) {
+    for (std::size_t i = 0; i < alternation.alternatives.size(); ++i) {
+        for (std::size_t j = i + 1; j < alternation.alternatives.size(); ++j) {
+            if (GroupsOverlap(
+                    dictionaries, alternation.alternatives[i], *children[i], alternation.alternatives[j], *children[j]
+                )) {
                 throw PatternSyntaxError(fmt::format(
-                    "Alternation alternatives {} and {} overlap: both can produce `{}`",
-                    describe(it->second),
-                    describe(i),
-                    it->first
+                    "Alternation branches `{}` and `{}` overlap: they can produce the same slug",
+                    alternation.alternatives[i].ToString(),
+                    alternation.alternatives[j].ToString()
                 ));
             }
         }
@@ -472,15 +592,31 @@ void CheckAlternativesDisjoint(
 }
 
 template <typename DictSet>
+auto BuildGroupGenerator(const DictSet& dictionaries, const Pattern::Group& group) -> SubstitutionGeneratorPtr {
+    // A bare single placeholder with no surrounding text is exactly that placeholder -- build it
+    // directly (no group wrapper), so placeholder alternation `{a}|{b}` keeps its seed stepping and
+    // stays byte-identical to before groups existed.
+    if (group.placeholders.size() == 1 && group.text_chunks[0].empty() && group.text_chunks[1].empty()) {
+        return BuildSimpleGenerator(dictionaries, group.placeholders[0]);
+    }
+    std::vector<SubstitutionGeneratorPtr> generators;
+    generators.reserve(group.placeholders.size());
+    for (const auto& placeholder : group.placeholders) {
+        generators.push_back(BuildSimpleGenerator(dictionaries, placeholder));
+    }
+    return std::make_unique<GroupSubstitutionGenerator>(std::move(generators), group.text_chunks);
+}
+
+template <typename DictSet>
 auto BuildAlternationGenerator(const DictSet& dictionaries, const Pattern::Alternation& alternation, bool validate)
     -> SubstitutionGeneratorPtr {
     std::vector<SubstitutionGeneratorPtr> children;
     children.reserve(alternation.alternatives.size());
-    for (const auto& alternative : alternation.alternatives) {
-        children.push_back(BuildSimpleGenerator(dictionaries, alternative));
+    for (const auto& branch : alternation.alternatives) {
+        children.push_back(BuildGroupGenerator(dictionaries, branch));
     }
     if (validate) {
-        CheckAlternativesDisjoint(children, alternation);
+        CheckAlternativesDisjoint(dictionaries, children, alternation);
     }
     return std::make_unique<AlternationSubstitutionGenerator>(std::move(children));
 }

--- a/slugkit/src/slugkit/generator/pattern_generator.hpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.hpp
@@ -235,6 +235,31 @@ private:
     std::size_t max_length_;
 };
 
+/// @brief Substitution generator for an alternation branch group `( ... )`: a flat sub-pattern of
+/// literal text interleaved with placeholders. Composes its placeholders exactly like the top-level
+/// pattern (seed-stepped, LCM capacity) and formats with the group's own text, so a lone/pulled-up
+/// group is byte-identical to writing its contents unparenthesised.
+class GroupSubstitutionGenerator : public SubstitutionGenerator {
+public:
+    GroupSubstitutionGenerator(std::vector<SubstitutionGeneratorPtr> generators, Pattern::TextChunks text_chunks);
+    ~GroupSubstitutionGenerator() override = default;
+
+    std::string Generate(std::uint32_t seed, std::size_t sequence_number) const override;
+
+    numeric::BigInt GetCapacity() const override {
+        return capacity_;
+    }
+    std::size_t GetMaxLength() const override {
+        return max_length_;
+    }
+
+private:
+    std::vector<SubstitutionGeneratorPtr> generators_;
+    Pattern::TextChunks text_chunks_;
+    numeric::BigInt capacity_;
+    std::size_t max_length_;
+};
+
 //-------------------------------------------------------------
 // PatternGenerator
 //-------------------------------------------------------------

--- a/slugkit/tests/generator_test.cpp
+++ b/slugkit/tests/generator_test.cpp
@@ -458,4 +458,32 @@ UTEST(PatternGenerator, AlternationCollapseAndDisjoint) {
     EXPECT_NO_THROW(PatternGenerator(kDictionariesSet, "{noun}|{verb}"_pattern_ptr));
 }
 
+UTEST(PatternGenerator, GroupAlternation) {
+    auto seed_hash = PatternGenerator::SeedHash(kTestSeed);
+
+    // Pull-up: a lone group is transparent -- same capacity AND same output as unparenthesised.
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "({noun})"_pattern_ptr).GetCapacity(), 5);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "({adjective} {noun})"_pattern_ptr).GetCapacity(), 35);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "pre-({adjective} {noun})-post"_pattern_ptr).GetCapacity(), 35);
+    {
+        PatternGenerator grouped(kDictionariesSet, "({adjective} {noun})"_pattern_ptr);
+        PatternGenerator plain(kDictionariesSet, "{adjective} {noun}"_pattern_ptr);
+        for (std::uint64_t i = 0; i < 20; ++i) {
+            EXPECT_EQ(grouped(seed_hash, i), plain(seed_hash, i));  // pull-up is exact
+        }
+    }
+
+    // Group alternation capacity is the sum of the branches' LCMs:
+    // LCM(noun=5, verb=10)=10; LCM(adjective=7, adverb=9)=63; total 73.
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "({noun} {verb})|({adjective} {adverb})"_pattern_ptr).GetCapacity(), 73);
+    EXPECT_EQ(PatternGenerator(kDictionariesSet, "(foo)|(bar)"_pattern_ptr).GetCapacity(), 2);
+
+    // Disjoint branches are fine; overlapping ones are a pattern error (subset at every position).
+    EXPECT_NO_THROW(PatternGenerator(kDictionariesSet, "({noun} {verb})|({adjective} {adverb})"_pattern_ptr));
+    EXPECT_THROW(
+        PatternGenerator(kDictionariesSet, "({noun:+tag1} {adjective})|({noun} {adjective})"_pattern_ptr),
+        PatternSyntaxError
+    );
+}
+
 }  // namespace slugkit::generator

--- a/slugkit/tests/pattern_test.cpp
+++ b/slugkit/tests/pattern_test.cpp
@@ -700,4 +700,52 @@ UTEST(PlaceholdersParser, AlternationCollapsesEquivalentAlternatives) {
     EXPECT_EQ(ParsePattern("{noun}|{noun}").ToString(), "{noun}");
 }
 
+UTEST(PlaceholdersParser, GroupAlternation) {
+    {
+        auto placeholders = ParsePlaceholders("({a} {b})|({c} {d})");
+        ASSERT_EQ(placeholders.size(), 1);
+        ASSERT_TRUE(std::holds_alternative<Pattern::Alternation>(placeholders[0]));
+        const auto& alternation = std::get<Pattern::Alternation>(placeholders[0]);
+        ASSERT_EQ(alternation.alternatives.size(), 2);
+        EXPECT_EQ(alternation.alternatives[0].placeholders.size(), 2);
+        EXPECT_EQ(alternation.alternatives[1].placeholders.size(), 2);
+    }
+    {
+        // Text-only branches.
+        auto placeholders = ParsePlaceholders("(foo)|(bar)");
+        ASSERT_EQ(placeholders.size(), 1);
+        const auto& alternation = std::get<Pattern::Alternation>(placeholders[0]);
+        ASSERT_EQ(alternation.alternatives.size(), 2);
+        EXPECT_EQ(alternation.alternatives[0].placeholders.size(), 0);
+    }
+}
+
+UTEST(PlaceholdersParser, GroupPullUp) {
+    // A lone group is transparent (parentheses are pulled up).
+    {
+        auto placeholders = ParsePlaceholders("({noun})");
+        ASSERT_EQ(placeholders.size(), 1);
+        EXPECT_TRUE(std::holds_alternative<Selector>(placeholders[0]));  // not an alternation/group
+    }
+    EXPECT_EQ(ParsePlaceholders("pre-({adjective} {noun})-post").size(), 2);  // two top-level placeholders
+    EXPECT_EQ(ParsePlaceholders("(foo)").size(), 0);                          // pure literal text
+    // Round-trip: alternation keeps parens; lone/collapsed groups drop them.
+    EXPECT_EQ(ParsePattern("({adjective} {noun})|{verb}").ToString(), "({adjective} {noun})|{verb}");
+    EXPECT_EQ(ParsePattern("(foo)|(bar)").ToString(), "(foo)|(bar)");
+    EXPECT_EQ(ParsePattern("({noun})").ToString(), "{noun}");
+    EXPECT_EQ(ParsePattern("pre-({adjective} {noun})-post").ToString(), "pre-{adjective} {noun}-post");
+}
+
+UTEST(PlaceholdersParser, GroupErrorsAndEscaping) {
+    EXPECT_THROW(ParsePlaceholders("()"), PatternSyntaxError);        // empty group
+    EXPECT_THROW(ParsePlaceholders("(a|b)"), PatternSyntaxError);     // '|' inside a group
+    EXPECT_THROW(ParsePlaceholders("(({a}))"), PatternSyntaxError);   // nested group
+    EXPECT_THROW(ParsePlaceholders("{noun})"), PatternSyntaxError);   // unmatched ')'
+    // Escaped parentheses are literal text: they format to plain parens and round-trip.
+    auto pattern = ParsePattern("a\\(b\\)c");
+    EXPECT_EQ(pattern.placeholders.size(), 0);
+    EXPECT_EQ(pattern.Format({}), "a(b)c");
+    EXPECT_EQ(pattern.ToString(), "a\\(b\\)c");
+}
+
 }  // namespace slugkit::generator


### PR DESCRIPTION
## What

Implements the design from the merged RFC (#31): parenthesised **groups** can be alternated, so correlated ("locked") tag choices across placeholders are expressible.

```
({Name:+given+male-unisex} {Name:+surname+male-unisex})
  |({Name:+given+female-unisex} {Name:+surname+female-unisex})
  |({Name:+given+unisex} {Name:+surname+unisex})
```

A given name and surname share the same gender branch — no female given name with a male surname. Tags are locked **by construction**; the per-placeholder machinery is untouched.

## How

**Model.** `Pattern::Group` (a flat sub-pattern: text + simple placeholders); alternation branches change from `SimplePlaceholder` to `Group`. A group is a mini pattern generator (LCM its placeholders, format with its own text) fed into the existing **child-agnostic** alternation generator. `TextChunks` become owned `std::string` (was `string_view`) so lone/collapsed groups can pull up by concatenating boundary text; `FormatChunks` is factored out of `SlugFormatter` and shared.

**Parser.** Reserve `(` `)` (with `\(` `\)` escapes); rework the main loop to a pending-text accumulator. A bare `{a}` branch is a one-placeholder group. **Pull-up:** a lone group or a single-collapse alternation is inlined into the enclosing pattern — parentheses are transparent, giving *exact* equivalence (same capacity **and** output). A bare single-placeholder branch keeps the direct generator (no wrapper), so placeholder alternation stays byte-identical. Empty groups rejected; equivalent branches collapsed by `Group::GetHash`.

**Validation.** Branches must be pairwise disjoint. **Per-position refinement** for same-shape branches: `(A₀×A₁×…) ∩ (B₀×B₁×…)` is empty iff any aligned position is disjoint — so it enumerates each *placeholder* (cheap), not the cross-product, and catches a forgotten `-unisex`. Different-shape branches fall back to bounded full-output enumeration; pairs too large to decide are allowed.

## Testing

Verified on host:
- **Pull-up is byte-identical** to unparenthesised (`({adjective} {noun})` == `{adjective} {noun}` over 20 sequences).
- Group capacity = **sum of branch LCMs** (`({noun} {verb})|({adjective} {adverb})` = 10 + 63 = 73; the adverb/emoji example = 8,352,652).
- `(foo)|(bar)`, `\(`/`\)` escaping, boundary-text merge (`pre-({adv} x{emoji})-post`).
- Errors: empty group, `|`/`(` inside a group, unmatched `)`, and the per-position overlap `({adverb:+pos} …)|({adverb} …)`.
- **golden_test 12/12, c_abi_test all pass**; placeholder alternation and all prior goldens intact (byte-identical).

## Notes

- Pattern serialisation stores only the source string (re-parsed), so no `io/` changes (as #29).
- The **userver service build wasn't compiled here** (no userver in this env) — devcontainer build is the final check.
- v1 is flat (groups contain simple placeholders, no nesting), per the RFC.