### PR TITLE
feat: empty alternation branch `()` (explicit "or nothing")

### DIFF
--- a/group-alternation-proposal.md
+++ b/group-alternation-proposal.md
@@ -230,9 +230,12 @@ branch is provably disjoint without enumerating any cross-product.
 
 ## 12. Edge cases
 
-- `()` — empty group (no placeholders, no text): **rejected** with a clear error
-  (decided), matching the "useless generator" checks elsewhere. (A text-only group
-  like `(foo)` is fine — it just pulls up to the literal `foo`.)
+- `()` — empty group (no placeholders, no text): allowed **only as an alternation
+  branch** (an explicit "or nothing" option, e.g. `({adverb})|()`, capacity +1). A
+  standalone or all-empty `()` (including `()|()`, which collapses to one) is
+  rejected. Its generator is the ordinary 0-placeholder group: capacity 1, length
+  0, output `""` — no dedicated empty-generator type. (A text-only group like
+  `(foo)` is fine — it pulls up to the literal `foo`.)
 - `(   )` whitespace-only — treated as literal text group of that whitespace.
 - Unbalanced `(` or `)` — parse error with column.
 - Nested `((…))` — parse error in v1 (flat only).

--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -210,9 +210,22 @@ int main(void) {
             /* Per-position overlap error: same second placeholder, first is a superset. */
             char* go = slk_generate_alloc(mg, "({adverb:+pos} {emoji})|({adverb} {emoji})", "s", 0, &err);
             CHECK(go == NULL, "overlapping group branches are rejected (per-position)");
-            /* Empty group is rejected. */
+            /* Standalone empty group is rejected. */
             char* eg = slk_generate_alloc(mg, "()", "s", 0, &err);
-            CHECK(eg == NULL, "empty group `()` is rejected");
+            CHECK(eg == NULL, "standalone empty group `()` is rejected");
+            /* But an empty branch is an explicit "or nothing" option (capacity +1). */
+            char* ec = NULL;
+            slk_capacity(mg, "({adverb})|()", &ec, NULL, &err);
+            CHECK(ec && strcmp(ec, "3620") == 0, "empty alternation branch adds 1 to capacity");
+            slk_string_free(ec);
+            int saw_empty = 0, saw_foo = 0;
+            for (int s = 0; s < 4; s++) {
+                char* g = slk_generate_alloc(mg, "(foo)|()", "s", s, &err);
+                if (g && g[0] == 0) saw_empty = 1;
+                if (g && strcmp(g, "foo") == 0) saw_foo = 1;
+                slk_string_free(g);
+            }
+            CHECK(saw_empty && saw_foo, "(foo)|() produces both `foo` and the empty string");
 
             slk_generator_destroy(mg);
         }

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -257,6 +257,21 @@ TEST(PatternGenerator, GroupAlternation) {
         PatternGenerator(dictionaries, "({noun:+tag1} {adjective})|({noun} {adjective})"_pattern_ptr),
         PatternSyntaxError
     );
+
+    // An empty branch `()` is an explicit "or nothing" option (capacity +1) among other branches.
+    {
+        PatternGenerator optional_noun(dictionaries, "({noun})|()"_pattern_ptr);
+        EXPECT_EQ(optional_noun.GetCapacity(), 6);  // 5 nouns + the empty option
+        std::set<std::string> seen;
+        for (std::uint64_t i = 0; i < 6; ++i) {
+            seen.insert(optional_noun(seed_hash, i));
+        }
+        EXPECT_EQ(seen.count(""), 1u);  // the empty string is produced
+        EXPECT_EQ(seen.size(), 6u);     // collision-free: 5 nouns + ""
+    }
+    // A standalone or all-empty alternation is rejected.
+    EXPECT_THROW(ParsePattern("()"), PatternSyntaxError);
+    EXPECT_THROW(ParsePattern("()|()"), PatternSyntaxError);
 }
 
 // End-to-end generator: committed full-slug expectations from generator_test.cpp (GenerateID).

--- a/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
+++ b/slugkit/src/slugkit/generator/detail/pattern_parser.hpp
@@ -601,17 +601,18 @@ struct PatternParser {
 
     // Parse one alternation branch: a parenthesised group `( ... )`, or a bare placeholder `{ ... }`
     // wrapped as a single-placeholder group with no surrounding text.
+    // True for `()`: no placeholders and no literal text. Meaningful only as an alternation branch
+    // (an explicit empty option); rejected standalone.
+    static bool IsEmptyGroup(const Pattern::Group& group) {
+        return group.placeholders.empty() && group.text_chunks.size() == 1 && group.text_chunks[0].empty();
+    }
+
     Pattern::Group ParseAlternationElement() {
         if (Match(kGroupOpen)) {
             Next();  // consume '('
             auto group = ParseGroupBody();
             Expect(kGroupClose);
-            if (group.placeholders.empty() && group.text_chunks.size() == 1 && group.text_chunks[0].empty()) {
-                throw PatternSyntaxError(
-                    fmt::format("Pattern parse error: empty group `()` at column {}", GetCurrentColumn())
-                );
-            }
-            return group;
+            return group;  // an empty group is allowed here; validity depends on the alternation (below)
         }
         Expect('{');
         Pattern::Group group;
@@ -747,6 +748,14 @@ struct PatternParser {
 
                 if (distinct.size() == 1) {
                     // Lone group / all-equivalent alternation: pull up (parentheses are transparent).
+                    // A lone `()` is meaningless (an empty option needs siblings), so reject it.
+                    if (IsEmptyGroup(distinct.front())) {
+                        throw PatternSyntaxError(fmt::format(
+                            "Pattern parse error: empty group `()` at column {}; it is only valid as an "
+                            "alternation branch alongside others (e.g. `({{adverb}})|()`)",
+                            GetCurrentColumn()
+                        ));
+                    }
                     pull_up(std::move(distinct.front()));
                 } else {
                     push_element(Pattern::Alternation{std::move(distinct)});

--- a/slugkit/tests/generator_test.cpp
+++ b/slugkit/tests/generator_test.cpp
@@ -484,6 +484,20 @@ UTEST(PatternGenerator, GroupAlternation) {
         PatternGenerator(kDictionariesSet, "({noun:+tag1} {adjective})|({noun} {adjective})"_pattern_ptr),
         PatternSyntaxError
     );
+
+    // An empty branch `()` is an explicit "or nothing" option (capacity +1); standalone `()` is not.
+    {
+        PatternGenerator optional_noun(kDictionariesSet, "({noun})|()"_pattern_ptr);
+        EXPECT_EQ(optional_noun.GetCapacity(), 6);
+        std::set<std::string> seen;
+        for (std::uint64_t i = 0; i < 6; ++i) {
+            seen.insert(optional_noun(seed_hash, i));
+        }
+        EXPECT_EQ(seen.count(""), 1u);  // the empty option is produced
+        EXPECT_EQ(seen.size(), 6u);
+    }
+    EXPECT_THROW(ParsePattern("()"), PatternSyntaxError);
+    EXPECT_THROW(ParsePattern("()|()"), PatternSyntaxError);
 }
 
 }  // namespace slugkit::generator

--- a/slugkit/tests/pattern_test.cpp
+++ b/slugkit/tests/pattern_test.cpp
@@ -737,10 +737,13 @@ UTEST(PlaceholdersParser, GroupPullUp) {
 }
 
 UTEST(PlaceholdersParser, GroupErrorsAndEscaping) {
-    EXPECT_THROW(ParsePlaceholders("()"), PatternSyntaxError);        // empty group
+    EXPECT_THROW(ParsePlaceholders("()"), PatternSyntaxError);        // standalone empty group
+    EXPECT_THROW(ParsePlaceholders("()|()"), PatternSyntaxError);     // all-empty collapses to standalone
     EXPECT_THROW(ParsePlaceholders("(a|b)"), PatternSyntaxError);     // '|' inside a group
     EXPECT_THROW(ParsePlaceholders("(({a}))"), PatternSyntaxError);   // nested group
     EXPECT_THROW(ParsePlaceholders("{noun})"), PatternSyntaxError);   // unmatched ')'
+    // But an empty branch is allowed as an explicit "or nothing" option in an alternation.
+    EXPECT_EQ(ParsePlaceholders("({noun})|()").size(), 1);
     // Escaped parentheses are literal text: they format to plain parens and round-trip.
     auto pattern = ParsePattern("a\\(b\\)c");
     EXPECT_EQ(pattern.placeholders.size(), 0);


### PR DESCRIPTION
## What

Allow an empty group `()` as an **alternation branch** — an explicit optional element:

```
({adverb})|()        -> an adverb OR the empty string   (capacity = adverbs + 1)
(pre-{emoji})|()     -> "pre-<emoji>" OR ""
```

A **standalone** or **all-empty** `()` (including `()|()`, which collapses to one empty branch) is still **rejected** — a lone empty option is meaningless.

## How

Per the discussion: **Option A** (allow `()` in alternation), and **no** standalone `{empty}` keyword. There's **no new generator type** — as noted, the empty branch is just the ordinary 0-placeholder `GroupSubstitutionGenerator`: capacity 1, max length 0, output `""`. So this is a **parser-only** change: the empty-group check moves from "always reject" to "reject only when it's the lone result after collapse".

Disjointness already handles it: the empty branch's output `{""}` doesn't coincide with any selector/number/emoji output, and `()|()` collapses by hash before the check.

## Testing

Verified on host:
- `(foo)|()` produces **both** `foo` and `""`; `({adverb})|()` has capacity **3620** (3619 + 1); `({noun})|()` is collision-free over `{noun1..noun5, ""}`.
- Standalone `()` and `()|()` are **rejected**.
- **golden_test 12/12, c_abi_test all pass**; everything else intact.

Proposal doc (`group-alternation-proposal.md`, §12) updated to reflect the revised rule.

## Notes

As with the alternation PRs, the **userver service build wasn't compiled here** (no userver in env).