### PR TITLE
feat: honest opt-in tags (hidden by default, per-generator usage flag)

### DIFF
--- a/bindings/dart/test/slugkit_test.dart
+++ b/bindings/dart/test/slugkit_test.dart
@@ -73,16 +73,18 @@ void main() {
     test('capacity of {adverb}-{emoji}', () {
       final g = openMulti();
       final cap = g.capacity('{adverb}-{emoji}');
-      expect(cap.value, '4176326');
+      // Opt-in tags are hidden by default: test-adv marks `nsfw` opt-in (4 adverbs), so the
+      // adverb pool is 3615 and 3615 * 1154 emoji = 4171710.
+      expect(cap.value, '4171710');
       expect(cap.maxLength, 22);
       g.dispose();
     });
 
     test('{adverb}-{emoji} golden prefixes', () {
       final g = openMulti();
-      expect(g.generate('{adverb}-{emoji}', 'foobar', 0), startsWith('lustfully-'));
-      expect(g.generate('{adverb}-{emoji}', 'foobar', 1), startsWith('abroad-'));
-      expect(g.generate('{adverb}-{emoji}', 'foobar', 2), startsWith('maladroitly-'));
+      expect(g.generate('{adverb}-{emoji}', 'foobar', 0), startsWith('impotently-'));
+      expect(g.generate('{adverb}-{emoji}', 'foobar', 1), startsWith('speechlessly-'));
+      expect(g.generate('{adverb}-{emoji}', 'foobar', 2), startsWith('diagonally-'));
       g.dispose();
     });
 

--- a/bindings/flutter/slugkit/README.md
+++ b/bindings/flutter/slugkit/README.md
@@ -18,7 +18,7 @@ final emoji = (await rootBundle.load('assets/emoji.bin')).buffer.asUint8List();
 final adverb = (await rootBundle.load('assets/test-adv.slugs')).buffer.asUint8List();
 
 final gen = Generator.fromMultiple([adverb, emoji]);
-final slug = gen.generate('{adverb}-{emoji}', 'foobar', 0);   // e.g. "lustfully-🐝"
+final slug = gen.generate('{adverb}-{emoji}', 'foobar', 0);   // e.g. "impotently-🐝"
 final cap  = gen.capacity('{adverb}-{emoji}');                // cap.value, cap.maxLength
 final many = gen.generateBatch('{adverb}-{emoji}', 'foobar', 0, 20);
 gen.dispose();

--- a/bindings/flutter/slugkit/example/integration_test/app_test.dart
+++ b/bindings/flutter/slugkit/example/integration_test/app_test.dart
@@ -26,14 +26,15 @@ void main() {
 
   test('capacity of {adverb}-{emoji}', () {
     final cap = gen.capacity('{adverb}-{emoji}');
-    expect(cap.value, '4176326');
+    // Opt-in `nsfw` (4 adverbs) hidden by default -> pool 3615, 3615 * 1154 = 4171710.
+    expect(cap.value, '4171710');
     expect(cap.maxLength, 22);
   });
 
   test('{adverb}-{emoji} golden prefixes', () {
-    expect(gen.generate('{adverb}-{emoji}', 'foobar', 0), startsWith('lustfully-'));
-    expect(gen.generate('{adverb}-{emoji}', 'foobar', 1), startsWith('abroad-'));
-    expect(gen.generate('{adverb}-{emoji}', 'foobar', 2), startsWith('maladroitly-'));
+    expect(gen.generate('{adverb}-{emoji}', 'foobar', 0), startsWith('impotently-'));
+    expect(gen.generate('{adverb}-{emoji}', 'foobar', 1), startsWith('speechlessly-'));
+    expect(gen.generate('{adverb}-{emoji}', 'foobar', 2), startsWith('diagonally-'));
   });
 
   test('{adverb:<=5}-{number:3d} golden values', () {

--- a/bindings/kotlin/scripts/Verify.kt
+++ b/bindings/kotlin/scripts/Verify.kt
@@ -38,12 +38,13 @@ fun main(args: Array<String>) {
     // Golden values (seed "foobar") are byte-identical across all language bindings.
     Generator.fromBinaryDictionaries(listOf(adverb, emoji)).use { gen ->
         val cap = gen.capacity("{adverb}-{emoji}")
-        check(cap.value == "4176326") { "multi capacity=${cap.value}" }
+        // Opt-in `nsfw` (4 adverbs) hidden by default -> pool 3615, 3615 * 1154 = 4171710.
+        check(cap.value == "4171710") { "multi capacity=${cap.value}" }
         check(cap.maxLength == 22) { "multi maxLength=${cap.maxLength}" }
 
-        check(gen.generate("{adverb}-{emoji}", "foobar", 0).startsWith("lustfully-")) { "seq0 prefix" }
-        check(gen.generate("{adverb}-{emoji}", "foobar", 1).startsWith("abroad-")) { "seq1 prefix" }
-        check(gen.generate("{adverb}-{emoji}", "foobar", 2).startsWith("maladroitly-")) { "seq2 prefix" }
+        check(gen.generate("{adverb}-{emoji}", "foobar", 0).startsWith("impotently-")) { "seq0 prefix" }
+        check(gen.generate("{adverb}-{emoji}", "foobar", 1).startsWith("speechlessly-")) { "seq1 prefix" }
+        check(gen.generate("{adverb}-{emoji}", "foobar", 2).startsWith("diagonally-")) { "seq2 prefix" }
 
         check(gen.generate("{adverb:<=5}-{number:3d}", "foobar", 0) == "ago-887") { "num seq0" }
         check(gen.generate("{adverb:<=5}-{number:3d}", "foobar", 1) == "aloud-774") { "num seq1" }

--- a/bindings/swift/Tests/SlugkitTests/SlugkitTests.swift
+++ b/bindings/swift/Tests/SlugkitTests/SlugkitTests.swift
@@ -35,15 +35,16 @@ final class SlugkitTests: XCTestCase {
 
     func testMultiCapacity() throws {
         let cap = try multi().capacity(of: "{adverb}-{emoji}")
-        XCTAssertEqual(cap.value, "4176326")
+        // Opt-in `nsfw` (4 adverbs) hidden by default -> pool 3615, 3615 * 1154 = 4171710.
+        XCTAssertEqual(cap.value, "4171710")
         XCTAssertEqual(cap.maxLength, 22)
     }
 
     func testMultiGoldenPrefixes() throws {
         let gen = try multi()
-        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 0).hasPrefix("lustfully-"))
-        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 1).hasPrefix("abroad-"))
-        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 2).hasPrefix("maladroitly-"))
+        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 0).hasPrefix("impotently-"))
+        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 1).hasPrefix("speechlessly-"))
+        XCTAssertTrue(try gen.generate("{adverb}-{emoji}", seed: "foobar", sequence: 2).hasPrefix("diagonally-"))
     }
 
     func testMultiLengthAndNumberGolden() throws {

--- a/slugkit/host/CMakeLists.txt
+++ b/slugkit/host/CMakeLists.txt
@@ -66,6 +66,8 @@ enable_testing()
 find_package(GTest REQUIRED)
 
 add_executable(golden_test ${CMAKE_CURRENT_SOURCE_DIR}/golden_test.cpp)
+target_compile_definitions(golden_test PRIVATE
+    SLK_ADVERB_BIN_PATH="${SLUGKIT_DIR}/tests/data/test-adv.slugs")
 target_link_libraries(golden_test PRIVATE
     slugkit-generator-host
     GTest::gtest

--- a/slugkit/host/c_abi_test.c
+++ b/slugkit/host/c_abi_test.c
@@ -144,17 +144,19 @@ int main(void) {
         if (mg != NULL) {
             char* mc = NULL;
             int32_t mml = 0;
+            /* Default capacity hides opt-in tags: test-adv marks `nsfw` opt-in (4 adverbs), so the
+             * adverb pool is 3619 - 4 = 3615 here. 3615 * 1154 emoji = 4171710. */
             slk_capacity(mg, "{adverb}-{emoji}", &mc, &mml, &err);
-            CHECK(mc && strcmp(mc, "4176326") == 0 && mml == 22, "capacity({adverb}-{emoji}) == 4176326");
+            CHECK(mc && strcmp(mc, "4171710") == 0 && mml == 22, "capacity({adverb}-{emoji}) == 4171710 (nsfw hidden)");
             slk_string_free(mc);
 
             /* {adverb}-{emoji}: adverb prefix is ASCII and deterministic (emoji suffix varies by build's font, not bytes) */
             char* w0 = slk_generate_alloc(mg, "{adverb}-{emoji}", "foobar", 0, &err);
             char* w1 = slk_generate_alloc(mg, "{adverb}-{emoji}", "foobar", 1, &err);
             char* w2 = slk_generate_alloc(mg, "{adverb}-{emoji}", "foobar", 2, &err);
-            CHECK(w0 && strncmp(w0, "lustfully-", 10) == 0, "{adverb}-{emoji} seq0 starts 'lustfully-'");
-            CHECK(w1 && strncmp(w1, "abroad-", 7) == 0, "{adverb}-{emoji} seq1 starts 'abroad-'");
-            CHECK(w2 && strncmp(w2, "maladroitly-", 12) == 0, "{adverb}-{emoji} seq2 starts 'maladroitly-'");
+            CHECK(w0 && strncmp(w0, "impotently-", 11) == 0, "{adverb}-{emoji} seq0 starts 'impotently-'");
+            CHECK(w1 && strncmp(w1, "speechlessly-", 13) == 0, "{adverb}-{emoji} seq1 starts 'speechlessly-'");
+            CHECK(w2 && strncmp(w2, "diagonally-", 11) == 0, "{adverb}-{emoji} seq2 starts 'diagonally-'");
             slk_string_free(w0);
             slk_string_free(w1);
             slk_string_free(w2);
@@ -173,7 +175,7 @@ int main(void) {
             /* Placeholder alternation: capacity is the sum of the children (adverb + emoji). */
             char* ac = NULL;
             slk_capacity(mg, "{adverb}|{emoji}", &ac, NULL, &err);
-            CHECK(ac && strcmp(ac, "4773") == 0, "capacity({adverb}|{emoji}) == 4773 (3619 adverbs + 1154 emoji)");
+            CHECK(ac && strcmp(ac, "4769") == 0, "capacity({adverb}|{emoji}) == 4769 (3615 adverbs + 1154 emoji)");
             slk_string_free(ac);
             /* Escaped pipe is a literal pipe in the output. */
             char* esc = slk_generate_alloc(mg, "x\\|y", "s", 0, &err);
@@ -185,7 +187,7 @@ int main(void) {
             /* Equivalent alternatives collapse: {adverb}|{adverb} has the capacity of one {adverb}. */
             char* cc = NULL;
             slk_capacity(mg, "{adverb}|{adverb}", &cc, NULL, &err);
-            CHECK(cc && strcmp(cc, "3619") == 0, "{adverb}|{adverb} collapses to capacity 3619");
+            CHECK(cc && strcmp(cc, "3615") == 0, "{adverb}|{adverb} collapses to capacity 3615");
             slk_string_free(cc);
             /* Overlapping alternatives ({adverb} is a superset of {adverb:+pos}) are a pattern error. */
             char* ov = slk_generate_alloc(mg, "{adverb:+pos}|{adverb}", "s", 0, &err);
@@ -202,10 +204,10 @@ int main(void) {
             char* ep = slk_generate_alloc(mg, "a\\(b\\)c", "s", 0, &err);
             CHECK(ep && strcmp(ep, "a(b)c") == 0, "escaped parens `a\\(b\\)c` -> `a(b)c`");
             slk_string_free(ep);
-            /* Group alternation capacity = sum of branch LCMs: LCM(3619,1154)*2 = 8352652. */
+            /* Group alternation capacity = sum of branch LCMs: LCM(3615,1154)*2 = 8343420 (nsfw hidden). */
             char* gc = NULL;
             slk_capacity(mg, "({adverb} {emoji})|({emoji} {adverb})", &gc, NULL, &err);
-            CHECK(gc && strcmp(gc, "8352652") == 0, "group alternation capacity is the sum of branch LCMs");
+            CHECK(gc && strcmp(gc, "8343420") == 0, "group alternation capacity is the sum of branch LCMs");
             slk_string_free(gc);
             /* Per-position overlap error: same second placeholder, first is a superset. */
             char* go = slk_generate_alloc(mg, "({adverb:+pos} {emoji})|({adverb} {emoji})", "s", 0, &err);
@@ -216,7 +218,7 @@ int main(void) {
             /* But an empty branch is an explicit "or nothing" option (capacity +1). */
             char* ec = NULL;
             slk_capacity(mg, "({adverb})|()", &ec, NULL, &err);
-            CHECK(ec && strcmp(ec, "3620") == 0, "empty alternation branch adds 1 to capacity");
+            CHECK(ec && strcmp(ec, "3616") == 0, "empty alternation branch adds 1 to capacity");
             slk_string_free(ec);
             int saw_empty = 0, saw_foo = 0;
             for (int s = 0; s < 4; s++) {
@@ -226,6 +228,34 @@ int main(void) {
                 slk_string_free(g);
             }
             CHECK(saw_empty && saw_foo, "(foo)|() produces both `foo` and the empty string");
+
+            /* --- honest opt-ins --- */
+            /* test-adv marks `nsfw` opt-in. By default those 4 adverbs are hidden (pool 3615),
+             * but an explicit `+nsfw` still selects exactly them. */
+            char* onc = NULL;
+            slk_capacity(mg, "{adverb}", &onc, NULL, &err);
+            CHECK(onc && strcmp(onc, "3615") == 0, "opt-in nsfw adverbs hidden by default (capacity 3615)");
+            slk_string_free(onc);
+            char* nc = NULL;
+            slk_capacity(mg, "{adverb:+nsfw}", &nc, NULL, &err);
+            CHECK(nc && strcmp(nc, "4") == 0, "explicit {adverb:+nsfw} still selects the 4 opt-in adverbs");
+            slk_string_free(nc);
+            /* Enabling the opt-in tag lifts the gate: the pool returns to the full 3619 and the
+             * output matches what the generator produced before opt-in filtering existed. */
+            CHECK(slk_generator_enable_opt_in(mg, "nsfw", &err) == SLK_OK, "slk_generator_enable_opt_in(nsfw) ok");
+            char* enc = NULL;
+            slk_capacity(mg, "{adverb}", &enc, NULL, &err);
+            CHECK(enc && strcmp(enc, "3619") == 0, "enabling nsfw restores full adverb pool (capacity 3619)");
+            slk_string_free(enc);
+            char* ew0 = slk_generate_alloc(mg, "{adverb}", "foobar", 0, &err);
+            CHECK(ew0 && strcmp(ew0, "lustfully") == 0, "enabled nsfw: {adverb} seq0 == 'lustfully'");
+            slk_string_free(ew0);
+            /* Clearing restores the default hidden behaviour. */
+            CHECK(slk_generator_clear_opt_ins(mg, &err) == SLK_OK, "slk_generator_clear_opt_ins ok");
+            char* cnc = NULL;
+            slk_capacity(mg, "{adverb}", &cnc, NULL, &err);
+            CHECK(cnc && strcmp(cnc, "3615") == 0, "clearing opt-ins hides nsfw again (capacity 3615)");
+            slk_string_free(cnc);
 
             slk_generator_destroy(mg);
         }

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -338,8 +338,15 @@ TEST(Generator, OptInTags) {
     EXPECT_EQ(generator.Generate("{adverb}", "foobar", 0), "lustfully");
     EXPECT_EQ(generator.EnabledOptIns(), (std::vector<std::string>{"nsfw"}));
 
-    // Clearing restores the default hidden behaviour.
+    // Clearing restores the default hidden behaviour. Reusing the same generator (whose shared
+    // filter cache already holds the enabled=3619 entry) proves the cache key accounts for the
+    // opt-in state: a stale entry would wrongly return 3619 here.
     generator.ClearOptIns();
+    EXPECT_EQ(generator.GetCapacity("{adverb}").capacity, 3615);
+
+    // Enabling a tag this dictionary does not have is inert: the adverb pool stays 3615 (and its
+    // cache key is unchanged), since only a dictionary's own opt-in tags affect its result.
+    generator.EnableOptIn("no-such-opt-in-tag");
     EXPECT_EQ(generator.GetCapacity("{adverb}").capacity, 3615);
 }
 #endif  // SLK_ADVERB_BIN_PATH

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -5,6 +5,7 @@
 // / property-stable slug output without userver. The mixed-case section mirrors the property-based
 // form introduced by PR #20.
 
+#include <slugkit/generator/binary_dictionary.hpp>
 #include <slugkit/generator/exceptions.hpp>
 #include <slugkit/generator/generator.hpp>
 #include <slugkit/generator/pattern_generator.hpp>
@@ -12,7 +13,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <fstream>
 #include <iostream>
+#include <iterator>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -299,6 +304,45 @@ TEST(Generator, SelfConsistent) {
         EXPECT_FALSE(a.empty());
     }
 }
+
+#ifdef SLK_ADVERB_BIN_PATH
+namespace {
+// Load a compiled binary dictionary into a Generator. The file bytes are held alive by a shared
+// keepalive for the dictionary set's lifetime.
+binary::DictionarySet LoadBinaryAdverbs() {
+    std::ifstream file(SLK_ADVERB_BIN_PATH, std::ios::binary);
+    auto bytes = std::make_shared<std::vector<std::byte>>();
+    for (std::istreambuf_iterator<char> it(file), end; it != end; ++it) {
+        bytes->push_back(static_cast<std::byte>(*it));
+    }
+    binary::DictionarySet dictionaries;
+    dictionaries.Add(binary::DictionarySet::RawData{bytes->data(), bytes->size()}, bytes);
+    return dictionaries;
+}
+}  // namespace
+
+// Honest opt-ins (binary path): test-adv marks `nsfw` opt-in (4 adverbs). They are hidden by
+// default, selectable with an explicit `+nsfw`, and unhidden by the per-generator usage flag.
+TEST(Generator, OptInTags) {
+    Generator generator(LoadBinaryAdverbs());
+
+    // Default: the 4 nsfw adverbs are hidden -> pool is 3619 - 4 = 3615.
+    EXPECT_EQ(generator.GetCapacity("{adverb}").capacity, 3615);
+    // Explicit request still selects exactly the opt-in words.
+    EXPECT_EQ(generator.GetCapacity("{adverb:+nsfw}").capacity, 4);
+
+    // Enabling the tag lifts its gate: the pool returns to the full 3619 and the output matches
+    // what the engine produced before opt-in filtering existed.
+    generator.EnableOptIn("nsfw");
+    EXPECT_EQ(generator.GetCapacity("{adverb}").capacity, 3619);
+    EXPECT_EQ(generator.Generate("{adverb}", "foobar", 0), "lustfully");
+    EXPECT_EQ(generator.EnabledOptIns(), (std::vector<std::string>{"nsfw"}));
+
+    // Clearing restores the default hidden behaviour.
+    generator.ClearOptIns();
+    EXPECT_EQ(generator.GetCapacity("{adverb}").capacity, 3615);
+}
+#endif  // SLK_ADVERB_BIN_PATH
 
 // Turkish probe: captures the utf8proc casing reference (no ICU parity assumed). Asserts only
 // determinism, and prints the produced bytes for the report.

--- a/slugkit/include/slugkit/c/slugkit_c.h
+++ b/slugkit/include/slugkit/c/slugkit_c.h
@@ -64,6 +64,21 @@ void slk_generator_destroy(slk_generator* gen);
 char* slk_random_seed(slk_generator* gen, char** err_out);
 
 /**
+ * Enable an opt-in tag ("honest opt-ins").
+ *
+ * Tags flagged opt-in in the dictionary (e.g. "nsfw") are hidden by default: a word carrying one
+ * is produced only when a selector requests that tag explicitly (e.g. "{noun:+nsfw}") or when the
+ * tag has been enabled here. Enabling lifts the tag's gate for this generator without restricting
+ * output to it. This is a per-generator usage flag, not part of the pattern grammar. It changes
+ * which words a pattern can produce (and its capacity), so set it before generating rather than
+ * concurrently with generation. Enabling is cumulative; use slk_generator_clear_opt_ins to reset.
+ */
+slk_status slk_generator_enable_opt_in(slk_generator* gen, const char* tag, char** err_out);
+
+/** Disable all opt-in tags (restore the default: every opt-in tag hidden). */
+slk_status slk_generator_clear_opt_ins(slk_generator* gen, char** err_out);
+
+/**
  * Compute the capacity of a pattern.
  * @param capacity_decimal_out on success receives a heap-allocated decimal string of the
  *        (arbitrary-precision) capacity. Free with slk_string_free. May be NULL to skip.

--- a/slugkit/include/slugkit/generator/binary_dictionary.hpp
+++ b/slugkit/include/slugkit/generator/binary_dictionary.hpp
@@ -124,7 +124,11 @@ public:
         return tags_table_->Tags();
     }
 
-    auto Filter(const Selector& selector) const -> FilteredDictionaryPtr;
+    /// @brief Filter the dictionary by a selector.
+    /// @param enabled_opt_ins Tags whose opt-in gate is lifted for this request (the "honest
+    /// opt-in" usage flag). A word carrying an opt-in tag is hidden unless that tag is either
+    /// requested explicitly via the selector's include tags or listed here.
+    auto Filter(const Selector& selector, const TagSet& enabled_opt_ins = {}) const -> FilteredDictionaryPtr;
 
     auto operator[](LanguageCodeView language) const -> const LanguageInfo&;
     auto operator[](Tag tag) const -> const TagEntry&;
@@ -154,6 +158,10 @@ private:
     const detail::TagsTable* tags_table_;
     const detail::WordData* word_data_;
     std::shared_ptr<FilterCache> filter_cache_;
+    // Names of tags flagged opt-in (TagEntry::OptIn()), viewing the mmap'd tag strings.
+    // Precomputed once so Filter subtracts only these (few) tags rather than rescanning the
+    // whole tags table (thousands of entries for the emoji dictionary) on every request.
+    std::vector<TagView> opt_in_tags_;
 };
 
 /// @brief A set of binary dictionaries keyed by kind, the binary counterpart of
@@ -175,7 +183,8 @@ public:
     /// @brief Filter by selector, dispatching on kind. Mirrors the in-memory DictionarySet:
     /// a selector with no language defaults to "en"; an unknown kind or language yields an
     /// empty result (rather than throwing).
-    [[nodiscard]] auto Filter(const Selector& selector) const -> FilteredDictionaryPtr;
+    [[nodiscard]] auto Filter(const Selector& selector, const TagSet& enabled_opt_ins = {}) const
+        -> FilteredDictionaryPtr;
 
     [[nodiscard]] auto Contains(std::string_view kind) const -> bool {
         return dictionaries_.find(std::string{kind}) != dictionaries_.end();

--- a/slugkit/include/slugkit/generator/dictionary.hpp
+++ b/slugkit/include/slugkit/generator/dictionary.hpp
@@ -111,8 +111,11 @@ public:
     /// Will return an empty dictionary if the selector is empty or if the selector's kind is not the same as the
     /// dictionary's kind.
     /// @param selector The selector to use for filtering.
+    /// @param enabled_opt_ins Opt-in tags lifted for this request (the "honest opt-in" usage
+    /// flag). Accepted for signature parity with the binary dictionary; the in-memory dictionary
+    /// carries no opt-in tag metadata today, so it is currently a no-op here.
     /// @return The filtered dictionary.
-    FilteredDictionaryConstPtr Filter(const Selector& selector) const;
+    FilteredDictionaryConstPtr Filter(const Selector& selector, const TagSet& enabled_opt_ins = {}) const;
     FilteredDictionaryConstPtr Filter(const EmojiGen::TagsType& include_tags, const EmojiGen::TagsType& exclude_tags)
         const;
 
@@ -140,7 +143,7 @@ class DictionarySet {
 public:
     DictionarySet(std::vector<Dictionary> dictionaries);
 
-    FilteredDictionaryConstPtr Filter(const Selector& selector) const;
+    FilteredDictionaryConstPtr Filter(const Selector& selector, const TagSet& enabled_opt_ins = {}) const;
 
     auto size() const -> std::size_t {
         return dictionaries_.size();

--- a/slugkit/include/slugkit/generator/generator.hpp
+++ b/slugkit/include/slugkit/generator/generator.hpp
@@ -9,7 +9,9 @@
 #include <slugkit/compat/fast_pimpl.hpp>
 
 #include <map>
+#include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace slugkit::generator {
@@ -32,6 +34,25 @@ public:
     ~Generator() noexcept;
 
     [[nodiscard]] auto RandomSeed() const -> std::string;
+
+    //@{
+    /// @name Opt-in tags ("honest opt-ins")
+    /// Tags flagged opt-in in the dictionary are hidden by default: a word carrying one is only
+    /// produced when a selector requests that tag explicitly (e.g. `{noun:+nsfw}`) or when the
+    /// tag has been enabled here. This is a per-generator usage flag, not part of the pattern
+    /// grammar. Enabling a tag lifts its gate without restricting output to it (unlike `+tag`).
+    /// Enabling changes which words a pattern can produce and therefore its capacity, so treat
+    /// these as configuration to be set before generation (not concurrently with it).
+
+    /// @brief Lift the opt-in gate for a single tag.
+    void EnableOptIn(std::string_view tag);
+    /// @brief Replace the set of enabled opt-in tags.
+    void SetEnabledOptIns(std::vector<std::string> tags);
+    /// @brief Disable all opt-in tags (restore the default: every opt-in tag hidden).
+    void ClearOptIns();
+    /// @brief The currently enabled opt-in tags (sorted).
+    [[nodiscard]] auto EnabledOptIns() const -> std::vector<std::string>;
+    //@}
 
     /// @brief Calculates the maximum capacity and settings for a given pattern.
     /// @param pattern The pattern to calculate the capacity for.
@@ -150,6 +171,11 @@ private:
 #endif
     struct Impl;
     slugkit::compat::FastPimpl<Impl, kPimplSize, kPimplAlign> impl_;
+
+    // Enabled opt-in tags (owning). Kept outside the pimpl so adding it never disturbs the
+    // per-toolchain pimpl sizing. A std::set node's string address is stable, so a TagSet view
+    // built from these entries stays valid for the duration of a filter call.
+    std::set<std::string> enabled_opt_ins_;
 };
 
 using DictionaryStatistics = std::vector<DictionaryStats>;

--- a/slugkit/src/slugkit/c/slugkit_c.cpp
+++ b/slugkit/src/slugkit/c/slugkit_c.cpp
@@ -107,6 +107,40 @@ char* slk_random_seed(slk_generator* gen, char** err_out) {
     }
 }
 
+slk_status slk_generator_enable_opt_in(slk_generator* gen, const char* tag, char** err_out) {
+    if (gen == nullptr || tag == nullptr) {
+        SetErr(err_out, "slk_generator_enable_opt_in: null argument");
+        return SLK_ERR_INVALID_ARG;
+    }
+    try {
+        gen->gen.EnableOptIn(std::string_view{tag});
+        return SLK_OK;
+    } catch (const std::exception& e) {
+        SetErr(err_out, e.what());
+        return SLK_ERR_INTERNAL;
+    } catch (...) {
+        SetErr(err_out, "unknown error");
+        return SLK_ERR_INTERNAL;
+    }
+}
+
+slk_status slk_generator_clear_opt_ins(slk_generator* gen, char** err_out) {
+    if (gen == nullptr) {
+        SetErr(err_out, "slk_generator_clear_opt_ins: null generator");
+        return SLK_ERR_INVALID_ARG;
+    }
+    try {
+        gen->gen.ClearOptIns();
+        return SLK_OK;
+    } catch (const std::exception& e) {
+        SetErr(err_out, e.what());
+        return SLK_ERR_INTERNAL;
+    } catch (...) {
+        SetErr(err_out, "unknown error");
+        return SLK_ERR_INTERNAL;
+    }
+}
+
 slk_status slk_capacity(slk_generator* gen, const char* pattern, char** capacity_decimal_out, int32_t* max_len_out,
                         char** err_out) {
     if (gen == nullptr || pattern == nullptr) {

--- a/slugkit/src/slugkit/generator/binary_dictionary.cpp
+++ b/slugkit/src/slugkit/generator/binary_dictionary.cpp
@@ -9,6 +9,27 @@
 namespace slugkit::generator::binary {
 
 namespace {
+// Salt the filter-cache key with the set of enabled opt-in tags so that two requests differing
+// only in which opt-in tags are enabled (e.g. nsfw on vs off) never share a cached filtered
+// dictionary. The filter cache is shared across every generator using this dictionary, so the
+// enabled set -- a per-generator property -- must be part of the key, not just the selector.
+auto OptInSalt(const TagSet& enabled_opt_ins) -> std::uint64_t {
+    std::uint64_t hash = 1469598103934665603ULL;  // FNV-1a offset basis
+    for (auto tag : enabled_opt_ins) {
+        for (char ch : tag.GetUnderlying()) {
+            hash = (hash ^ static_cast<unsigned char>(ch)) * 1099511628211ULL;
+        }
+        hash = (hash ^ 0xFFu) * 1099511628211ULL;  // separator between tags
+    }
+    return hash;
+}
+
+auto CombineHash(std::int64_t selector_hash, std::uint64_t salt) -> std::int64_t {
+    auto value = static_cast<std::uint64_t>(selector_hash);
+    value ^= salt + 0x9e3779b97f4a7c15ULL + (value << 6) + (value >> 2);
+    return static_cast<std::int64_t>(value);
+}
+
 auto CheckPointer(const std::byte* base, std::string_view name, std::int64_t alignment = 4) -> void {
     if (base == nullptr) {
         throw DictionaryDataError(fmt::format("Invalid {}: base is nullptr", name));
@@ -595,6 +616,14 @@ BinaryDictionary::BinaryDictionary(RawData data)
     filter_cache_ = std::make_shared<FilterCache>(kFilterCacheWays, kFilterCacheWaySize);
 
     Validate();
+
+    // Collect opt-in tags once (post-validation, so the tags table is known-good). Filter
+    // subtracts these unless the tag is requested explicitly or enabled for the request.
+    for (const auto& tag_entry : *tags_table_) {
+        if (tag_entry.OptIn()) {
+            opt_in_tags_.push_back(tag_entry.Name());
+        }
+    }
 }
 
 auto BinaryDictionary::Validate() const -> void {
@@ -626,17 +655,26 @@ auto BinaryDictionary::operator[](IndexType index) const -> const WordEntry& {
     return word_data_->At(offset);
 }
 
-auto BinaryDictionary::Filter(const Selector& selector) const -> FilteredDictionaryPtr {
+auto BinaryDictionary::Filter(const Selector& selector, const TagSet& enabled_opt_ins) const
+    -> FilteredDictionaryPtr {
     // Reuse the built filtered dictionary for identical selectors (same language/tags/size/case);
     // building it (filter + max-length) is the expensive part, so caching keeps repeated patterns
-    // cheap under load. Keyed by the selector's identity hash, same as the in-memory path.
-    const auto hash = selector.GetHash();
+    // cheap under load. Keyed by the selector's identity hash, salted with the enabled opt-in set
+    // so requests differing only in enabled opt-ins get distinct cache entries.
+    const auto hash = CombineHash(selector.GetHash(), OptInSalt(enabled_opt_ins));
     if (auto cached = filter_cache_->Get(hash)) {
         return *cached;
     }
     auto index_sequence = language_table_->Filter(selector.language, selector.size_limit);
     auto indices = tags_table_->Filter(index_sequence, selector.include_tags, selector.exclude_tags);
-    // TODO opt-in tags
+    // Honest opt-ins: hide words carrying an opt-in tag unless that tag was requested explicitly
+    // (selector include tags) or its opt-in gate was lifted for this request (enabled_opt_ins).
+    for (auto opt_in_tag : opt_in_tags_) {
+        if (selector.include_tags.contains(opt_in_tag) || enabled_opt_ins.contains(opt_in_tag)) {
+            continue;
+        }
+        indices = indices - (*tags_table_)[opt_in_tag].Filter();
+    }
     auto filtered = std::make_shared<FilteredDictionary>(indices, index_table_, word_data_, selector.GetCase());
     filter_cache_->Put(hash, filtered);
     return filtered;
@@ -652,7 +690,8 @@ void DictionarySet::Add(RawData data, std::shared_ptr<void> keepalive) {
     dictionaries_.insert_or_assign(std::move(kind), std::move(dictionary));
 }
 
-auto DictionarySet::Filter(const Selector& selector) const -> FilteredDictionaryPtr {
+auto DictionarySet::Filter(const Selector& selector, const TagSet& enabled_opt_ins) const
+    -> FilteredDictionaryPtr {
     auto kind = utils::text::ToLower(selector.kind, utils::text::kEnUsLocale);
     auto it = dictionaries_.find(kind);
     if (it == dictionaries_.end()) {
@@ -678,7 +717,7 @@ auto DictionarySet::Filter(const Selector& selector) const -> FilteredDictionary
     } else if (languages.find(*effective.language) == languages.end()) {
         return {};
     }
-    return dictionary.Filter(effective);
+    return dictionary.Filter(effective, enabled_opt_ins);
 }
 
 }  // namespace slugkit::generator::binary

--- a/slugkit/src/slugkit/generator/binary_dictionary.cpp
+++ b/slugkit/src/slugkit/generator/binary_dictionary.cpp
@@ -9,19 +9,16 @@
 namespace slugkit::generator::binary {
 
 namespace {
-// Salt the filter-cache key with the set of enabled opt-in tags so that two requests differing
-// only in which opt-in tags are enabled (e.g. nsfw on vs off) never share a cached filtered
-// dictionary. The filter cache is shared across every generator using this dictionary, so the
-// enabled set -- a per-generator property -- must be part of the key, not just the selector.
-auto OptInSalt(const TagSet& enabled_opt_ins) -> std::uint64_t {
-    std::uint64_t hash = 1469598103934665603ULL;  // FNV-1a offset basis
-    for (auto tag : enabled_opt_ins) {
-        for (char ch : tag.GetUnderlying()) {
-            hash = (hash ^ static_cast<unsigned char>(ch)) * 1099511628211ULL;
-        }
-        hash = (hash ^ 0xFFu) * 1099511628211ULL;  // separator between tags
+// FNV-1a folding of a tag name into a running salt, used to key the filter cache by the set of
+// enabled opt-in tags that actually apply to a dictionary (see BinaryDictionary::Filter).
+constexpr std::uint64_t kFnvOffsetBasis = 1469598103934665603ULL;
+constexpr std::uint64_t kFnvPrime = 1099511628211ULL;
+
+auto FoldTag(std::uint64_t hash, std::string_view tag) -> std::uint64_t {
+    for (char ch : tag) {
+        hash = (hash ^ static_cast<unsigned char>(ch)) * kFnvPrime;
     }
-    return hash;
+    return (hash ^ 0xFFu) * kFnvPrime;  // separator so {"ab","c"} and {"a","bc"} differ
 }
 
 auto CombineHash(std::int64_t selector_hash, std::uint64_t salt) -> std::int64_t {
@@ -657,11 +654,24 @@ auto BinaryDictionary::operator[](IndexType index) const -> const WordEntry& {
 
 auto BinaryDictionary::Filter(const Selector& selector, const TagSet& enabled_opt_ins) const
     -> FilteredDictionaryPtr {
-    // Reuse the built filtered dictionary for identical selectors (same language/tags/size/case);
-    // building it (filter + max-length) is the expensive part, so caching keeps repeated patterns
-    // cheap under load. Keyed by the selector's identity hash, salted with the enabled opt-in set
-    // so requests differing only in enabled opt-ins get distinct cache entries.
-    const auto hash = CombineHash(selector.GetHash(), OptInSalt(enabled_opt_ins));
+    // Reuse the built filtered dictionary for identical requests (same language/tags/size/case
+    // AND the same set of applicable opt-in tags); building it (filter + max-length) is the
+    // expensive part, so caching keeps repeated patterns cheap under load.
+    //
+    // The filtered result depends on the opt-in set only through this dictionary's own opt-in
+    // tags that are enabled -- so the cache key is salted with exactly that set. Salting with
+    // only the applicable tags means (a) the cache is not fragmented by enabling opt-ins this
+    // dictionary doesn't have, and (b) a dictionary with no opt-in tags, or a request enabling
+    // none of them, keeps the same key it used before opt-ins existed (plain selector hash).
+    std::uint64_t salt = kFnvOffsetBasis;
+    bool has_applicable_opt_in = false;
+    for (auto opt_in_tag : opt_in_tags_) {
+        if (enabled_opt_ins.contains(opt_in_tag)) {
+            has_applicable_opt_in = true;
+            salt = FoldTag(salt, opt_in_tag.GetUnderlying());
+        }
+    }
+    const auto hash = has_applicable_opt_in ? CombineHash(selector.GetHash(), salt) : selector.GetHash();
     if (auto cached = filter_cache_->Get(hash)) {
         return *cached;
     }

--- a/slugkit/src/slugkit/generator/dictionary.cpp
+++ b/slugkit/src/slugkit/generator/dictionary.cpp
@@ -123,7 +123,11 @@ auto Dictionary::empty() const -> bool {
     return pimpl_->words_->empty();
 }
 
-auto Dictionary::Filter(const Selector& selector) const -> FilteredDictionaryConstPtr {
+auto Dictionary::Filter(const Selector& selector, const TagSet& enabled_opt_ins) const
+    -> FilteredDictionaryConstPtr {
+    // The in-memory dictionary carries no per-tag opt-in metadata (unlike the binary dictionary),
+    // so the enabled opt-in set is accepted for API parity but has no effect here yet.
+    (void)enabled_opt_ins;
     auto kind = utils::text::ToLower(selector.kind, utils::text::kEnUsLocale);
     if (kind != pimpl_->kind_) {
         return {};
@@ -165,7 +169,7 @@ DictionarySet::DictionarySet(std::vector<Dictionary> dictionaries)
     }
 }
 
-FilteredDictionaryConstPtr DictionarySet::Filter(const Selector& selector) const {
+FilteredDictionaryConstPtr DictionarySet::Filter(const Selector& selector, const TagSet& enabled_opt_ins) const {
     auto key = utils::text::ToLower(selector.kind, utils::text::kEnUsLocale);
     // TODO maybe merge language-agnostic and language-specific dictionaries
     if (language_agnostic_kinds_.find(key) != language_agnostic_kinds_.end()) {
@@ -177,7 +181,7 @@ FilteredDictionaryConstPtr DictionarySet::Filter(const Selector& selector) const
             );
             auto dict = dictionaries_.find(lang_key);
             if (dict != dictionaries_.end()) {
-                return dict->second.Filter(selector);
+                return dict->second.Filter(selector, enabled_opt_ins);
             }
         }
     } else {
@@ -194,7 +198,7 @@ FilteredDictionaryConstPtr DictionarySet::Filter(const Selector& selector) const
     if (dict == dictionaries_.end()) {
         return {};
     }
-    return dict->second.Filter(selector);
+    return dict->second.Filter(selector, enabled_opt_ins);
 }
 
 }  // namespace slugkit::generator

--- a/slugkit/src/slugkit/generator/generator.cpp
+++ b/slugkit/src/slugkit/generator/generator.cpp
@@ -9,27 +9,50 @@
 
 namespace slugkit::generator {
 
+namespace {
+// Build a TagSet (views) over the generator's owning opt-in strings. std::set nodes are stable,
+// so the views stay valid while the source set is unchanged -- long enough for a filter call.
+auto MakeOptInView(const std::set<std::string>& enabled_opt_ins) -> TagSet {
+    TagSet view;
+    for (const auto& tag : enabled_opt_ins) {
+        view.emplace(std::string_view{tag});
+    }
+    return view;
+}
+}  // namespace
+
 struct Generator::Impl {
     // The generator works with either an in-memory or a binary (memory-mapped) dictionary
     // set; PatternGenerator accepts both and produces byte-identical slugs.
     std::variant<DictionarySet, binary::DictionarySet> dictionaries;
 
-    PatternSettings GetCapacity(PatternPtr pattern) const {
+    PatternSettings GetCapacity(PatternPtr pattern, const TagSet& enabled_opt_ins) const {
         // TODO LRU cache for pattern generators
         return std::visit(
-            [&](const auto& dict) { return PatternGenerator(dict, pattern).GetSettings(); }, dictionaries
+            [&](const auto& dict) { return PatternGenerator(dict, pattern, enabled_opt_ins).GetSettings(); },
+            dictionaries
         );
     }
 
-    std::string Generate(std::string_view pattern_str, std::string_view seed, std::size_t sequence_number) const {
+    std::string Generate(
+        std::string_view pattern_str,
+        std::string_view seed,
+        std::size_t sequence_number,
+        const TagSet& enabled_opt_ins
+    ) const {
         auto pattern = std::make_shared<Pattern>(std::string(pattern_str));
-        return Generate(pattern, seed, sequence_number);
+        return Generate(pattern, seed, sequence_number, enabled_opt_ins);
     }
 
-    std::string Generate(PatternPtr pattern, std::string_view seed, std::size_t sequence_number) const {
+    std::string Generate(
+        PatternPtr pattern,
+        std::string_view seed,
+        std::size_t sequence_number,
+        const TagSet& enabled_opt_ins
+    ) const {
         return std::visit(
             [&](const auto& dict) {
-                auto generator = PatternGenerator(dict, pattern);
+                auto generator = PatternGenerator(dict, pattern, enabled_opt_ins);
                 return generator(seed, sequence_number);
             },
             dictionaries
@@ -40,12 +63,13 @@ struct Generator::Impl {
         const PatternSettings& settings,
         PatternPtr pattern,
         std::string_view seed,
-        std::size_t sequence_number
+        std::size_t sequence_number,
+        const TagSet& enabled_opt_ins
     ) const {
         // TODO LRU cache for pattern generators
         return std::visit(
             [&](const auto& dict) {
-                auto generator = PatternGenerator(dict, pattern, settings);
+                auto generator = PatternGenerator(dict, pattern, settings, enabled_opt_ins);
                 return generator(seed, sequence_number);
             },
             dictionaries
@@ -57,10 +81,11 @@ struct Generator::Impl {
         std::string_view seed,
         std::size_t sequence_number,
         std::size_t count,
-        GenerateCallback callback
+        GenerateCallback callback,
+        const TagSet& enabled_opt_ins
     ) const {
         auto pattern = std::make_shared<Pattern>(std::string(pattern_str));
-        Generate(pattern, seed, sequence_number, count, callback);
+        Generate(pattern, seed, sequence_number, count, callback, enabled_opt_ins);
     }
 
     void Generate(
@@ -68,11 +93,12 @@ struct Generator::Impl {
         std::string_view seed,
         std::size_t sequence_number,
         std::size_t count,
-        GenerateCallback callback
+        GenerateCallback callback,
+        const TagSet& enabled_opt_ins
     ) const {
         std::visit(
             [&](const auto& dict) {
-                auto generator = PatternGenerator(dict, pattern);
+                auto generator = PatternGenerator(dict, pattern, enabled_opt_ins);
                 auto seed_hash = PatternGenerator::SeedHash(seed);
                 for (std::size_t i = 0; i < count; ++i) {
                     callback(generator(seed_hash, sequence_number + i));
@@ -88,12 +114,13 @@ struct Generator::Impl {
         std::string_view seed,
         std::size_t sequence_number,
         std::size_t count,
-        GenerateCallback callback
+        GenerateCallback callback,
+        const TagSet& enabled_opt_ins
     ) const {
         // TODO LRU cache for pattern generators
         std::visit(
             [&](const auto& dict) {
-                auto generator = PatternGenerator(dict, pattern, settings);
+                auto generator = PatternGenerator(dict, pattern, settings, enabled_opt_ins);
                 auto seed_hash = PatternGenerator::SeedHash(seed);
                 for (std::size_t i = 0; i < count; ++i) {
                     callback(generator(seed_hash, sequence_number + i));
@@ -122,22 +149,38 @@ std::string Generator::RandomSeed() const {
     return fmt::format("{:08x}", distribution(rng));
 }
 
+void Generator::EnableOptIn(std::string_view tag) {
+    enabled_opt_ins_.emplace(tag);
+}
+
+void Generator::SetEnabledOptIns(std::vector<std::string> tags) {
+    enabled_opt_ins_ = std::set<std::string>(std::make_move_iterator(tags.begin()), std::make_move_iterator(tags.end()));
+}
+
+void Generator::ClearOptIns() {
+    enabled_opt_ins_.clear();
+}
+
+std::vector<std::string> Generator::EnabledOptIns() const {
+    return std::vector<std::string>(enabled_opt_ins_.begin(), enabled_opt_ins_.end());
+}
+
 PatternSettings Generator::GetCapacity(std::string_view pattern_str) const {
     auto pattern = std::make_shared<Pattern>(std::string(pattern_str));
     return GetCapacity(pattern);
 }
 
 PatternSettings Generator::GetCapacity(PatternPtr pattern) const {
-    return impl_->GetCapacity(pattern);
+    return impl_->GetCapacity(pattern, MakeOptInView(enabled_opt_ins_));
 }
 
 std::string Generator::Generate(std::string_view pattern_str, std::string_view seed, std::size_t sequence_number)
     const {
-    return impl_->Generate(pattern_str, seed, sequence_number);
+    return impl_->Generate(pattern_str, seed, sequence_number, MakeOptInView(enabled_opt_ins_));
 }
 
 std::string Generator::Generate(PatternPtr pattern, std::string_view seed, std::size_t sequence_number) const {
-    return impl_->Generate(pattern, seed, sequence_number);
+    return impl_->Generate(pattern, seed, sequence_number, MakeOptInView(enabled_opt_ins_));
 }
 
 std::string Generator::Generate(
@@ -146,7 +189,7 @@ std::string Generator::Generate(
     std::string_view seed,
     std::size_t sequence_number
 ) const {
-    return impl_->Generate(settings, pattern, seed, sequence_number);
+    return impl_->Generate(settings, pattern, seed, sequence_number, MakeOptInView(enabled_opt_ins_));
 }
 
 void Generator::Generate(
@@ -157,7 +200,7 @@ void Generator::Generate(
     std::size_t count,
     GenerateCallback callback
 ) const {
-    return impl_->Generate(settings, pattern, seed, sequence_number, count, callback);
+    return impl_->Generate(settings, pattern, seed, sequence_number, count, callback, MakeOptInView(enabled_opt_ins_));
 }
 
 void Generator::Generate(
@@ -167,7 +210,7 @@ void Generator::Generate(
     std::size_t count,
     GenerateCallback callback
 ) const {
-    return impl_->Generate(pattern, seed, sequence_number, count, callback);
+    return impl_->Generate(pattern, seed, sequence_number, count, callback, MakeOptInView(enabled_opt_ins_));
 }
 
 void Generator::Generate(
@@ -177,7 +220,7 @@ void Generator::Generate(
     std::size_t count,
     GenerateCallback callback
 ) const {
-    return impl_->Generate(pattern_str, seed, sequence_number, count, callback);
+    return impl_->Generate(pattern_str, seed, sequence_number, count, callback, MakeOptInView(enabled_opt_ins_));
 }
 
 }  // namespace slugkit::generator

--- a/slugkit/src/slugkit/generator/pattern_generator.cpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.cpp
@@ -434,6 +434,25 @@ auto EmojiSelector(const EmojiGen& emoji_gen) -> Selector {
     return selector;
 }
 
+// Adapts a dictionary set together with the request's enabled opt-in tags into something the build
+// helpers can call `.Filter(selector)` on. This lets the "honest opt-in" usage flag ride along
+// every filter call without threading it through each helper's signature: the build code keeps
+// writing `dictionaries.Filter(selector)`, and the opt-in set is applied underneath.
+template <typename DictSet>
+struct OptInFilter {
+    const DictSet& dictionaries;
+    const TagSet& enabled_opt_ins;
+
+    auto Filter(const Selector& selector) const {
+        return dictionaries.Filter(selector, enabled_opt_ins);
+    }
+};
+
+template <typename DictSet>
+auto WithOptIns(const DictSet& dictionaries, const TagSet& enabled_opt_ins) -> OptInFilter<DictSet> {
+    return OptInFilter<DictSet>{dictionaries, enabled_opt_ins};
+}
+
 // Build a generator for one simple (non-alternating) placeholder. Used for alternation children.
 // Unlike the top-level path, selectors here use the plain dictionary size (no prime/LCM
 // maximization, which is a flat-composition heuristic; children compose by sum) and are not stored
@@ -630,36 +649,41 @@ struct PatternGenerator::Impl {
     PatternSettings settings;
 
     // Constructor for the case when settings are not calculated yet for the pattern
-    Impl(const DictionarySet& dictionaries, PatternPtr pattern)
+    Impl(const DictionarySet& dictionaries, PatternPtr pattern, const TagSet& enabled_opt_ins)
         : pattern{pattern}
         , generators{}
-        , settings{CalculateSettings(dictionaries)} {
+        , settings{CalculateSettings(WithOptIns(dictionaries, enabled_opt_ins))} {
         //
     }
 
     // Constructor for the case when settings are provided
-    Impl(const DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings)
+    Impl(const DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings, const TagSet& enabled_opt_ins)
         : pattern{pattern}
         , generators{}
         , settings{settings} {
-        InitGenerators(dictionaries);
+        InitGenerators(WithOptIns(dictionaries, enabled_opt_ins));
     }
 
     // Binary dictionary set overloads: the binary dictionaries reproduce the in-memory
     // dictionaries' lexicographic order, so the same settings/init logic applies and the
     // generated slugs are byte-identical.
-    Impl(const binary::DictionarySet& dictionaries, PatternPtr pattern)
+    Impl(const binary::DictionarySet& dictionaries, PatternPtr pattern, const TagSet& enabled_opt_ins)
         : pattern{pattern}
         , generators{}
-        , settings{CalculateSettings(dictionaries)} {
+        , settings{CalculateSettings(WithOptIns(dictionaries, enabled_opt_ins))} {
         //
     }
 
-    Impl(const binary::DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings)
+    Impl(
+        const binary::DictionarySet& dictionaries,
+        PatternPtr pattern,
+        PatternSettings settings,
+        const TagSet& enabled_opt_ins
+    )
         : pattern{pattern}
         , generators{}
         , settings{settings} {
-        InitGenerators(dictionaries);
+        InitGenerators(WithOptIns(dictionaries, enabled_opt_ins));
     }
 
     // This function has a side effect of initializing the generators
@@ -797,24 +821,38 @@ struct PatternGenerator::Impl {
     }
 };
 
-PatternGenerator::PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern)
-    : impl_{dictionaries, pattern} {
+PatternGenerator::PatternGenerator(
+    const DictionarySet& dictionaries,
+    PatternPtr pattern,
+    const TagSet& enabled_opt_ins
+)
+    : impl_{dictionaries, pattern, enabled_opt_ins} {
 }
 
-PatternGenerator::PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings)
-    : impl_{dictionaries, pattern, settings} {
-}
-
-PatternGenerator::PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern)
-    : impl_{dictionaries, pattern} {
+PatternGenerator::PatternGenerator(
+    const DictionarySet& dictionaries,
+    PatternPtr pattern,
+    PatternSettings settings,
+    const TagSet& enabled_opt_ins
+)
+    : impl_{dictionaries, pattern, settings, enabled_opt_ins} {
 }
 
 PatternGenerator::PatternGenerator(
     const binary::DictionarySet& dictionaries,
     PatternPtr pattern,
-    PatternSettings settings
+    const TagSet& enabled_opt_ins
 )
-    : impl_{dictionaries, pattern, settings} {
+    : impl_{dictionaries, pattern, enabled_opt_ins} {
+}
+
+PatternGenerator::PatternGenerator(
+    const binary::DictionarySet& dictionaries,
+    PatternPtr pattern,
+    PatternSettings settings,
+    const TagSet& enabled_opt_ins
+)
+    : impl_{dictionaries, pattern, settings, enabled_opt_ins} {
 }
 
 PatternGenerator::~PatternGenerator() = default;

--- a/slugkit/src/slugkit/generator/pattern_generator.hpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.hpp
@@ -273,10 +273,22 @@ private:
 /// @param seed The seed to use
 class PatternGenerator {
 public:
-    PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern);
-    PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings);
-    PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern);
-    PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern, PatternSettings settings);
+    // enabled_opt_ins: tags whose opt-in gate is lifted for this pattern (the "honest opt-in"
+    // usage flag). Empty (the default) hides every opt-in tag unless a selector requests it.
+    PatternGenerator(const DictionarySet& dictionaries, PatternPtr pattern, const TagSet& enabled_opt_ins = {});
+    PatternGenerator(
+        const DictionarySet& dictionaries,
+        PatternPtr pattern,
+        PatternSettings settings,
+        const TagSet& enabled_opt_ins = {}
+    );
+    PatternGenerator(const binary::DictionarySet& dictionaries, PatternPtr pattern, const TagSet& enabled_opt_ins = {});
+    PatternGenerator(
+        const binary::DictionarySet& dictionaries,
+        PatternPtr pattern,
+        PatternSettings settings,
+        const TagSet& enabled_opt_ins = {}
+    );
     ~PatternGenerator();
 
     /// @brief Generate a string from a pattern


### PR DESCRIPTION
## What

Tags flagged **opt-in** in a dictionary (e.g. `nsfw`) are now hidden by default. A word carrying an opt-in tag is produced only when:

1. a selector requests that tag **explicitly** — `{noun:+nsfw}` (unchanged include semantics: restricts to that tag), or
2. the tag has been **enabled** for the generator via the usage flag.

This is a **per-generator usage flag, not part of the pattern grammar** (as requested). Enabling a tag *lifts its gate* without restricting output to it (unlike `+tag`).

## How

The compiled **binary** dictionaries (the ones that ship to mobile) already carry per-tag opt-in metadata (`TagEntry::OptIn`), so the filtering lives there. The half-implemented `// TODO opt-in tags` markers are now done.

- **`BinaryDictionary::Filter`** precomputes its opt-in tags once at load, then subtracts any opt-in tag that is neither in the selector's include tags nor in the request's enabled set. Capacity follows automatically.
- The enabled set is **folded into the filter-cache key** — the cache is shared across generators, so two requests differing only in enabled opt-ins must not collide.
- The set threads `Generator → PatternGenerator → DictionarySet::Filter` via a tiny adapter, so every existing `dictionaries.Filter(selector)` call is byte-for-byte unchanged. Emoji use the same Filter path, so emoji opt-ins work too.
- Stored **outside the pimpl** on `Generator`, so no per-toolchain pimpl sizing moves.

### API
- C++: `Generator::EnableOptIn` / `SetEnabledOptIns` / `ClearOptIns` / `EnabledOptIns`.
- C ABI: `slk_generator_enable_opt_in` / `slk_generator_clear_opt_ins`.

### In-memory path
The in-memory dictionary has no per-tag opt-in metadata today (`TagIndex` hardcodes `opt_in=false`), so it accepts the enabled set for **API parity but is a no-op** there. Documented as a follow-up.

## Behaviour change

`test-adv.slugs` marks `nsfw` opt-in (4 adverbs). So `{adverb}`'s **default** capacity drops **3619 → 3615**; this is the intended effect and gives a real test case.

| pattern | before | after (default) | after `EnableOptIn("nsfw")` |
|---|---|---|---|
| `{adverb}` | 3619 | **3615** | 3619 |
| `{adverb:+nsfw}` | 4 | **4** (unchanged) | 4 |
| `{emoji}` | 1154 | **1154** (emoji has no opt-in tags) | 1154 |

## Testing

- **New** host `Generator.OptInTags` gtest (loads `test-adv.slugs`, drives `EnableOptIn` directly) and C-ABI opt-in checks: hidden by default, `+nsfw` still selects the 4, enabling restores 3619 **and the exact pre-filter output** (`lustfully`…), clearing hides them again.
- Binary-derived goldens that include `{adverb}` were **re-measured** in `c_abi_test` and every language binding (which assert only `{adverb}-{emoji}`).
- **In-memory goldens unchanged** (no opt-in source there) — `golden_test` 13/13, `c_abi_test` all pass.

## Not built here

The **userver service build** (no userver in this env) and the **Swift/Kotlin/Dart binding suites** (no toolchains) were not executed; binding goldens were updated by measurement against the same dictionaries.