### PR TITLE
fix: missing <algorithm>/<vector> includes for standalone builds

### DIFF
--- a/slugkit/include/slugkit/generator/placeholders.hpp
+++ b/slugkit/include/slugkit/generator/placeholders.hpp
@@ -3,11 +3,13 @@
 #include <slugkit/generator/constants.hpp>
 #include <slugkit/generator/types.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <optional>
 #include <string_view>
 #include <unordered_set>
+#include <vector>
 
 namespace slugkit::generator {
 

--- a/slugkit/include/slugkit/utils/small_map.hpp
+++ b/slugkit/include/slugkit/utils/small_map.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <stdexcept>
 


### PR DESCRIPTION
## Summary

Two headers rely on transitive includes that the `userver` build provides but a **userver-free** consumer (`SLUGKIT_USE_USERVER=OFF`) does not, so the standalone build fails to compile under libc++ / emscripten:

- `generator/placeholders.hpp` — uses `std::vector` and `std::set_intersection` → needs `<vector>`, `<algorithm>`
- `utils/small_map.hpp` — uses `std::copy` → needs `<algorithm>`

The `small_map.hpp` case is the nastier one: under emscripten's libc++ the unqualified `copy(...)` in the `SmallMap` initializer-list constructor silently resolved to POSIX **`bcopy`** (a `void*` byte copy) instead of `std::copy`, producing a confusing `cannot initialize a parameter of type 'void *'` error and, had it compiled, wrong behaviour.

Three one-line include additions; no functional change.

## How it was found

Embedding the standalone generator into a C++23 project that builds for both native (AppleClang/libc++) and **WASM (emscripten)**. The native build tolerated the `placeholders.hpp` gap via include order but emscripten did not; both headers fail cleanly with these includes added.

## Test plan
- [x] Standalone lib (`SLUGKIT_USE_USERVER=OFF`) compiles under AppleClang/libc++ (native)
- [x] Standalone lib compiles under emscripten (`emcmake`)
- [ ] CI standalone/host build (`slugkit/host`) — recommend adding a userver-free build to catch this class of regression