### PR TITLE
ci: add GitHub Actions PR gate (host + compiler + userver)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # Userver-free (standalone) build: the compat-shim + utf8proc core that ships to
+  # mobile. Builds golden_test + c_abi_test and runs them via ctest, on both the
+  # Linux/gcc+libstdc++ and macOS/clang+libc++ toolchains.
+  host-tests:
+    name: host tests (no userver) — ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake g++ libfmt-dev libboost-dev libutf8proc-dev libgtest-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install fmt boost utf8proc googletest
+
+      - name: Configure
+        run: >-
+          cmake -S slugkit/host -B build/host
+          ${{ runner.os == 'macOS' && '-DCMAKE_PREFIX_PATH=/opt/homebrew' || '' }}
+
+      - name: Build
+        run: cmake --build build/host --parallel
+
+      - name: Test
+        run: ctest --test-dir build/host --output-on-failure
+
+  # The Python dictionary compiler: install it, recompile the committed test
+  # fixtures from their YAML sources, and assert the binaries are byte-identical
+  # (catches a stale committed .bin or a non-deterministic compiler change).
+  compiler:
+    name: dictionary compiler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install compile-dict
+        run: pip install -e slugkit/py/tools
+
+      - name: Recompile fixtures and verify they match the committed binaries
+        run: |
+          set -euo pipefail
+          compile-dict slugkit/tests/data/multilang.yaml -o /tmp/multilang.yaml
+          compile-dict slugkit/tests/data/verbatim.yaml  -o /tmp/verbatim.yaml
+          cmp /tmp/multilang.colour.bin slugkit/tests/data/multilang.colour.bin
+          cmp /tmp/verbatim.corpus.bin  slugkit/tests/data/verbatim.corpus.bin
+
+  # Full userver build + UTEST suite, inside the prebuilt userver dev container
+  # (same image the monorepo builds with). ci/CMakeLists.txt is a thin entry point
+  # that finds the container's userver and builds the library + tests standalone.
+  # Requires the repo to be able to pull ghcr.io/slugkit/userver-build-amd64.
+  userver-tests:
+    name: userver tests
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/slugkit/userver-build-amd64:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S ci -B build/userver -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: cmake --build build/userver --parallel
+
+      - name: Test
+        run: ctest --test-dir build/userver --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,18 +73,22 @@ jobs:
           cmp /tmp/multilang.colour.bin slugkit/tests/data/multilang.colour.bin
           cmp /tmp/verbatim.corpus.bin  slugkit/tests/data/verbatim.corpus.bin
 
-  # Full userver build + UTEST suite, inside the prebuilt userver dev container
-  # (same image the monorepo builds with). ci/CMakeLists.txt is a thin entry point
-  # that finds the container's userver and builds the library + tests standalone.
-  # Requires the repo to be able to pull ghcr.io/slugkit/userver-build-amd64.
+  # Full userver build + UTEST suite, inside a PREBUILT userver dev container: userver is already
+  # compiled and installed in the image, so find_package(userver) resolves it and nothing rebuilds
+  # userver here. ci/CMakeLists.txt is a thin entry point that finds that userver and builds the
+  # library + tests standalone (mirrors poke-me's backend CMake: find_package + userver_setup_environment).
+  #
+  # Reuses poke-me's prebuilt image (same org, userver installed). Pulling it needs the repo to have
+  # read access to the package; grant that (or set a GHCR_PULL_TOKEN PAT secret) — the default
+  # GITHUB_TOKEN is used as a fallback.
   userver-tests:
     name: userver tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/slugkit/userver-build-amd64:latest
+      image: ghcr.io/slugkit/pokeme-userver-build-ci-amd64:latest
       credentials:
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}
     env:
       CC: clang
       CXX: clang++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The image bundles userver + fmt + boost but not utf8proc (a pure-C dep of utils/text.cpp).
+      - name: Install utf8proc
+        run: apt-get update && apt-get install -y --no-install-recommends libutf8proc-dev
+
       - name: Configure
         # Release matches how userver is built/installed in the prebuilt image; its CMake config
         # only ships the release targets file (a Debug configure looks for userver-targets_d.cmake).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -S ci -B build/userver -DCMAKE_BUILD_TYPE=Debug
+        # Release matches how userver is built/installed in the prebuilt image; its CMake config
+        # only ships the release targets file (a Debug configure looks for userver-targets_d.cmake).
+        run: cmake -S ci -B build/userver -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         run: cmake --build build/userver --parallel

--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -6,6 +6,10 @@ project(slugkit-generator-ci CXX)
 # libs/generator/slugkit. For standalone CI we find the userver that the
 # userver-build container already provides and build the library plus its
 # UTEST suite in isolation. Mirrors the monorepo's userver setup.
+# userver's exported targets reference fmt::fmt, so its imported target must exist before
+# userver's package config is loaded. (The monorepo pulls fmt in transitively; standalone we
+# find it explicitly. Both fmt and userver are installed in the prebuilt image.)
+find_package(fmt REQUIRED)
 find_package(userver REQUIRED COMPONENTS universal core)
 userver_setup_environment()
 

--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(slugkit-generator-ci CXX)
+
+# CI-only entry point. The generator library is normally consumed via
+# add_subdirectory from the parent monorepo, which sets up userver and adds
+# libs/generator/slugkit. For standalone CI we find the userver that the
+# userver-build container already provides and build the library plus its
+# UTEST suite in isolation. Mirrors the monorepo's userver setup.
+find_package(userver REQUIRED COMPONENTS universal core)
+userver_setup_environment()
+
+set(SLUGKIT_GENERATOR_BUILD_TESTS ON CACHE BOOL "" FORCE)
+enable_testing()
+
+# The generator's own CMakeLists lives one level up in slugkit/.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../slugkit ${CMAKE_BINARY_DIR}/slugkit)

--- a/slugkit/host/golden_test.cpp
+++ b/slugkit/host/golden_test.cpp
@@ -303,6 +303,24 @@ TEST(Generator, SelfConsistent) {
     }
 }
 
+// Honest opt-ins on an in-memory dictionary: flagging `nsfw` opt-in hides the one noun that carries
+// it (noun4) unless requested or enabled -- the same behaviour as the binary path, so the two
+// backends filter identically (see the userver BinaryParity tests).
+TEST(Generator, InMemoryOptIn) {
+    DictionarySet dictionaries{{Dictionary("noun", "en"_lang_view, kNouns, {"nsfw"_tag})}};
+    Generator generator(std::move(dictionaries));
+
+    // Hidden by default: 5 nouns minus noun4 (nsfw) = 4.
+    EXPECT_EQ(generator.GetCapacity("{noun}").capacity, 4);
+    // Explicit request still selects exactly the opt-in word.
+    EXPECT_EQ(generator.GetCapacity("{noun:+nsfw}").capacity, 1);
+    // Enabling lifts the gate; clearing restores the default.
+    generator.EnableOptIn("nsfw");
+    EXPECT_EQ(generator.GetCapacity("{noun}").capacity, 5);
+    generator.ClearOptIns();
+    EXPECT_EQ(generator.GetCapacity("{noun}").capacity, 4);
+}
+
 #if defined(SLK_ADVERB_BIN_PATH) || defined(SLK_MULTILANG_BIN_PATH) || defined(SLK_VERBATIM_BIN_PATH)
 namespace {
 // Load a compiled binary dictionary into a set. The memory-mapped file is the keepalive: it owns

--- a/slugkit/include/slugkit/generator/binary_dictionary.hpp
+++ b/slugkit/include/slugkit/generator/binary_dictionary.hpp
@@ -124,6 +124,12 @@ public:
         return tags_table_->Tags();
     }
 
+    /// @brief The tags flagged opt-in in this dictionary (TagEntry::OptIn()). Lets an in-memory
+    /// dictionary built from the same data mirror this dictionary's opt-in filtering.
+    [[nodiscard]] auto OptInTags() const -> TagSet {
+        return TagSet(opt_in_tags_.begin(), opt_in_tags_.end());
+    }
+
     /// @brief Filter the dictionary by a selector.
     /// @param enabled_opt_ins Tags whose opt-in gate is lifted for this request (the "honest
     /// opt-in" usage flag). A word carrying an opt-in tag is hidden unless that tag is either

--- a/slugkit/include/slugkit/generator/dictionary.hpp
+++ b/slugkit/include/slugkit/generator/dictionary.hpp
@@ -123,13 +123,15 @@ public:
     std::vector<TagDefinition> GetTagDefinitions() const;
 
 private:
-    // Impl size differs by toolchain/stdlib (userver/gcc+libstdc++ vs standalone clang+libc++),
-    // so the pimpl storage is sized per build.
+    // Impl size differs by toolchain/stdlib. The standalone (non-userver) FastPimpl treats the
+    // constant as an upper bound (static_assert Size >= sizeof(Impl)), so it must cover the
+    // largest standalone stdlib: libstdc++ (Linux) Impl is 96 bytes, libc++ (macOS/mobile) fits
+    // within that. The userver build uses strict equality and its own value.
 #ifdef SLUGKIT_USE_USERVER
     static constexpr std::size_t kPimplSize = 216UL;
     static constexpr std::size_t kPimplAlign = 8UL;
 #else
-    static constexpr std::size_t kPimplSize = 80UL;
+    static constexpr std::size_t kPimplSize = 96UL;
     static constexpr std::size_t kPimplAlign = 8UL;
 #endif
 

--- a/slugkit/include/slugkit/generator/dictionary.hpp
+++ b/slugkit/include/slugkit/generator/dictionary.hpp
@@ -88,7 +88,16 @@ class Dictionary {
     using WordContainerPtr = FilteredDictionary::WordContainerPtr;
 
 public:
-    Dictionary(std::string_view kind, LanguageCodeView language, std::vector<Word> words, bool use_cache = true);
+    /// @param opt_in_tags Tags flagged opt-in for this dictionary: a word carrying one is hidden
+    /// unless the tag is requested (selector include tags) or enabled per-request. Mirrors the
+    /// binary dictionary's opt-in metadata so the two backends filter identically.
+    Dictionary(
+        std::string_view kind,
+        LanguageCodeView language,
+        std::vector<Word> words,
+        std::set<Tag> opt_in_tags = {},
+        bool use_cache = true
+    );
 
     Dictionary(const Dictionary& other) noexcept;
     Dictionary(Dictionary&& other) noexcept;
@@ -112,8 +121,8 @@ public:
     /// dictionary's kind.
     /// @param selector The selector to use for filtering.
     /// @param enabled_opt_ins Opt-in tags lifted for this request (the "honest opt-in" usage
-    /// flag). Accepted for signature parity with the binary dictionary; the in-memory dictionary
-    /// carries no opt-in tag metadata today, so it is currently a no-op here.
+    /// flag). A word carrying one of this dictionary's opt-in tags is hidden unless that tag is
+    /// requested via the selector's include tags or listed here.
     /// @return The filtered dictionary.
     FilteredDictionaryConstPtr Filter(const Selector& selector, const TagSet& enabled_opt_ins = {}) const;
     FilteredDictionaryConstPtr Filter(const EmojiGen::TagsType& include_tags, const EmojiGen::TagsType& exclude_tags)
@@ -137,6 +146,11 @@ private:
 
     struct Impl;
     slugkit::compat::FastPimpl<Impl, kPimplSize, kPimplAlign> pimpl_;
+
+    // This dictionary's opt-in tag names (owning). Kept outside the pimpl so it never disturbs the
+    // per-toolchain pimpl sizing; Filter augments the selector's exclude tags with the ones that
+    // are neither requested nor enabled, so the existing tag-exclude path hides them.
+    std::set<Tag> opt_in_tags_;
 };
 
 /// @brief A set of dictionaries that can be used to generate human-readable IDs.

--- a/slugkit/include/slugkit/generator/generator.hpp
+++ b/slugkit/include/slugkit/generator/generator.hpp
@@ -160,13 +160,15 @@ public:
 
 private:
     // Holds a variant of the in-memory and binary dictionary sets.
-    // Impl size differs by toolchain/stdlib (userver/gcc+libstdc++ vs standalone clang+libc++),
-    // so the pimpl storage is sized per build.
+    // Impl size differs by toolchain/stdlib. The standalone (non-userver) FastPimpl treats the
+    // constant as an upper bound (static_assert Size >= sizeof(Impl)), so it must cover the
+    // largest standalone stdlib: libstdc++ (Linux) Impl is 104 bytes, libc++ (macOS/mobile) fits
+    // within that. The userver build uses strict equality and its own value.
 #ifdef SLUGKIT_USE_USERVER
     static constexpr std::size_t kPimplSize = 144UL;
     static constexpr std::size_t kPimplAlign = 8UL;
 #else
-    static constexpr std::size_t kPimplSize = 56UL;
+    static constexpr std::size_t kPimplSize = 104UL;
     static constexpr std::size_t kPimplAlign = 8UL;
 #endif
     struct Impl;

--- a/slugkit/src/slugkit/generator/dictionary.cpp
+++ b/slugkit/src/slugkit/generator/dictionary.cpp
@@ -88,8 +88,15 @@ struct Dictionary::Impl {
     }
 };
 
-Dictionary::Dictionary(std::string_view kind, LanguageCodeView language, std::vector<Word> words, bool use_cache)
-    : pimpl_{kind, language, std::move(words), use_cache} {
+Dictionary::Dictionary(
+    std::string_view kind,
+    LanguageCodeView language,
+    std::vector<Word> words,
+    std::set<Tag> opt_in_tags,
+    bool use_cache
+)
+    : pimpl_{kind, language, std::move(words), use_cache}
+    , opt_in_tags_{std::move(opt_in_tags)} {
 }
 
 Dictionary::Dictionary(const Dictionary& other) noexcept = default;
@@ -125,9 +132,6 @@ auto Dictionary::empty() const -> bool {
 
 auto Dictionary::Filter(const Selector& selector, const TagSet& enabled_opt_ins) const
     -> FilteredDictionaryConstPtr {
-    // The in-memory dictionary carries no per-tag opt-in metadata (unlike the binary dictionary),
-    // so the enabled opt-in set is accepted for API parity but has no effect here yet.
-    (void)enabled_opt_ins;
     auto kind = utils::text::ToLower(selector.kind, utils::text::kEnUsLocale);
     if (kind != pimpl_->kind_) {
         return {};
@@ -136,7 +140,20 @@ auto Dictionary::Filter(const Selector& selector, const TagSet& enabled_opt_ins)
         return {};
     }
 
-    return pimpl_->Filter(selector);
+    if (opt_in_tags_.empty()) {
+        return pimpl_->Filter(selector);
+    }
+    // Honest opt-ins: hide words carrying an opt-in tag that is neither requested (selector include
+    // tags) nor enabled for this request. Adding those tags to the selector's excludes reuses the
+    // existing tag-exclude path and yields the same word set the binary dictionary produces.
+    Selector effective = selector;
+    for (const auto& tag : opt_in_tags_) {
+        TagView tag_view{std::string_view{tag.GetUnderlying()}};
+        if (!selector.include_tags.contains(tag_view) && !enabled_opt_ins.contains(tag_view)) {
+            effective.exclude_tags.insert(tag_view);
+        }
+    }
+    return pimpl_->Filter(effective);
 }
 
 auto Dictionary::Filter(const EmojiGen::TagsType& include_tags, const EmojiGen::TagsType& exclude_tags) const

--- a/slugkit/src/slugkit/generator/pattern_generator.hpp
+++ b/slugkit/src/slugkit/generator/pattern_generator.hpp
@@ -310,13 +310,15 @@ public:
     static std::uint32_t SeedHash(std::string_view seed);
 
 private:
-    // Impl size differs by toolchain/stdlib (userver/gcc+libstdc++ vs standalone clang+libc++),
-    // so the pimpl storage is sized per build.
+    // Impl size differs by toolchain/stdlib. The standalone (non-userver) FastPimpl treats the
+    // constant as an upper bound (static_assert Size >= sizeof(Impl)), so it must cover the
+    // largest standalone stdlib: libstdc++ (Linux) Impl is 160 bytes, libc++ (macOS/mobile) fits
+    // within that. The userver build uses strict equality and its own value.
 #ifdef SLUGKIT_USE_USERVER
     static constexpr std::size_t kPimplSize = 160UL;
     static constexpr std::size_t kPimplAlign = 16UL;
 #else
-    static constexpr std::size_t kPimplSize = 144UL;
+    static constexpr std::size_t kPimplSize = 160UL;
     static constexpr std::size_t kPimplAlign = 16UL;
 #endif
     struct Impl;

--- a/slugkit/src/slugkit/generator/placeholders.cpp
+++ b/slugkit/src/slugkit/generator/placeholders.cpp
@@ -50,8 +50,11 @@ std::int64_t Selector::GetHash() const {
     for (const auto& tag : include_tags) {
         boost::hash_combine(seed, StrHash(tag.GetUnderlying().data(), tag.GetUnderlying().size()));
     }
+    // Salt exclude tags so `{x:+t}` and `{x:-t}` hash differently -- otherwise they collide (the
+    // filter cache would return the wrong set and equivalent-alternation collapse would merge them).
+    constexpr std::size_t kExcludeSalt = 0x9e3779b97f4a7c15ULL;
     for (const auto& exclude_tag : exclude_tags) {
-        boost::hash_combine(seed, StrHash(exclude_tag.GetUnderlying().data(), exclude_tag.GetUnderlying().size()));
+        boost::hash_combine(seed, StrHash(exclude_tag.GetUnderlying().data(), exclude_tag.GetUnderlying().size()) ^ kExcludeSalt);
     }
     if (size_limit.has_value()) {
         boost::hash_combine(seed, size_limit->GetHash());

--- a/slugkit/tests/binary_dictionary_test.cpp
+++ b/slugkit/tests/binary_dictionary_test.cpp
@@ -396,7 +396,8 @@ void TestFilteredBySize(std::span<const std::byte> data) {
     BinaryDictionary dictionary(data);
     auto filtered_dictionary = dictionary.Filter("adverb:<10"_selector);
     EXPECT_FALSE(filtered_dictionary->empty());
-    EXPECT_EQ(filtered_dictionary->size(), 3340);
+    // `nsfw` is opt-in and hidden by default: 3340 minus the 8 short nsfw adverbs (en + fr).
+    EXPECT_EQ(filtered_dictionary->size(), 3332);
 }
 
 UTEST(BinaryDictionary, InMemoryTestFilteredBySize) {
@@ -412,7 +413,8 @@ void TestFilteredByLangSize(std::span<const std::byte> data) {
     BinaryDictionary dictionary(data);
     auto filtered_dictionary = dictionary.Filter("adverb@en:<10"_selector);
     EXPECT_FALSE(filtered_dictionary->empty());
-    EXPECT_EQ(filtered_dictionary->size(), 1670);
+    // `nsfw` is opt-in and hidden by default: 1670 minus the 4 short nsfw adverbs (en).
+    EXPECT_EQ(filtered_dictionary->size(), 1666);
 }
 
 // Enumerating filtered positions 0..size-1 must map (via the filtered index sequence) to
@@ -421,7 +423,7 @@ void TestFilteredByLangSize(std::span<const std::byte> data) {
 void TestFilteredEnumeration(std::span<const std::byte> data) {
     BinaryDictionary dictionary(data);
     auto filtered = dictionary.Filter("adverb@en:<10"_selector);
-    ASSERT_EQ(filtered->size(), 1670u);
+    ASSERT_EQ(filtered->size(), 1666u);  // 1670 minus the 4 hidden opt-in (nsfw) adverbs
     EXPECT_EQ((*filtered)[0_idx].Lowercase(), "aback");
     EXPECT_EQ((*filtered)[IndexType(filtered->size() - 1)].Lowercase(), "zigzag");
 

--- a/slugkit/tests/binary_parity_test.cpp
+++ b/slugkit/tests/binary_parity_test.cpp
@@ -90,6 +90,13 @@ auto BuildInMemorySet(const binary::BinaryDictionary& dict) -> DictionarySet {
         }
     }
 
+    // Mirror the binary dictionary's opt-in tags onto the in-memory dictionaries so both backends
+    // hide the same words by default -- that byte-identical output is the parity contract.
+    std::set<Tag> opt_in_tags;
+    for (auto opt_in_tag : dict.OptInTags()) {
+        opt_in_tags.insert(Tag{std::string{opt_in_tag.GetUnderlying()}});
+    }
+
     std::vector<Dictionary> dictionaries;
     for (const auto& lang : dict.Languages()) {
         const auto& info = dict[lang];
@@ -106,7 +113,7 @@ auto BuildInMemorySet(const binary::BinaryDictionary& dict) -> DictionarySet {
             }
             words.push_back(std::move(w));
         }
-        dictionaries.emplace_back(kind, lang, std::move(words));
+        dictionaries.emplace_back(kind, lang, std::move(words), opt_in_tags);
     }
     return DictionarySet{std::move(dictionaries)};
 }

--- a/slugkit/tests/pattern_test.cpp
+++ b/slugkit/tests/pattern_test.cpp
@@ -640,8 +640,11 @@ UTEST(PlaceholdersParser, Alternation) {
         ASSERT_TRUE(std::holds_alternative<Pattern::Alternation>(placeholders[0]));
         const auto& alternation = std::get<Pattern::Alternation>(placeholders[0]);
         ASSERT_EQ(alternation.alternatives.size(), 2);
-        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[0]));
-        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[1]));
+        // Alternatives are Groups; a bare placeholder is a single-placeholder group with no text.
+        ASSERT_EQ(alternation.alternatives[0].placeholders.size(), 1);
+        ASSERT_EQ(alternation.alternatives[1].placeholders.size(), 1);
+        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[0].placeholders[0]));
+        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[1].placeholders[0]));
     }
     {
         // Whitespace around the pipe is allowed; alternatives may be of mixed placeholder kinds.
@@ -649,9 +652,9 @@ UTEST(PlaceholdersParser, Alternation) {
         ASSERT_EQ(placeholders.size(), 1);
         const auto& alternation = std::get<Pattern::Alternation>(placeholders[0]);
         ASSERT_EQ(alternation.alternatives.size(), 3);
-        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[0]));
-        EXPECT_TRUE(std::holds_alternative<NumberGen>(alternation.alternatives[1]));
-        EXPECT_TRUE(std::holds_alternative<EmojiGen>(alternation.alternatives[2]));
+        EXPECT_TRUE(std::holds_alternative<Selector>(alternation.alternatives[0].placeholders[0]));
+        EXPECT_TRUE(std::holds_alternative<NumberGen>(alternation.alternatives[1].placeholders[0]));
+        EXPECT_TRUE(std::holds_alternative<EmojiGen>(alternation.alternatives[2].placeholders[0]));
     }
     // Surrounding text keeps a single alternation placeholder.
     EXPECT_EQ(ParsePlaceholders("pre-{noun}|{verb}-post").size(), 1);


### PR DESCRIPTION
## What

No CI existed. Adds a `ci` workflow (on `pull_request` + push-to-`main`), **all green**:

| Job | Runs |
|-----|------|
| **host-tests (ubuntu + macOS)** | Userver-free standalone build (the mobile core) on gcc/libstdc++ **and** clang/libc++ → `golden_test` + `c_abi_test` via ctest. |
| **compiler** | Installs `compile-dict`, recompiles the `multilang`/`verbatim` fixtures, asserts byte-identical `.bin`. |
| **userver-tests** | Full UTEST suite against **prebuilt** userver (no rebuild) inside the ghcr dev image, via `ci/CMakeLists.txt` (`find_package` + `userver_setup_environment`, mirroring poke-me). |

Modelled on poke-me's `pr-tests.yml`, minus deploy / pg sidecar.

## What the new CI caught (and this PR fixes)

Host-only validation had missed real breakage in code merged earlier this session; the userver job surfaced it:

- **FastPimpl sizes** — standalone constants were tuned on libc++; libstdc++ Impls are larger and tripped the `Size >= sizeof` assert. Raised `Generator` 56→104, `Dictionary` 80→96, `PatternGenerator` 144→160 (exact sizes from the CI compiler's static_assert context; libc++ still fits).
- **`pattern_test` compile error** — #32 changed `Alternation::alternatives` to `Group`; an older test still called `holds_alternative` on a branch. Fixed.
- **`Selector::GetHash` collision** — include and exclude tags hashed identically, so `{x:+t}` and `{x:-t}` collided in the filter cache and in alternation-collapse. Salted exclude tags.
- **In-memory opt-in (parity)** — #34 made opt-in binary-only, so `BinaryParity` (binary == in-memory) diverged. Added real in-memory opt-in support (hide opt-in-tagged words via implicit excludes; `Dictionary` takes its opt-in tags, `BinaryDictionary::OptInTags` exposes them). Updated the opt-in-reduced filtered counts.

## Notes

- `ci/CMakeLists.txt` is a **standalone CI entry point** (find userver → build generator + tests); the monorepo is unaffected (it adds `libs/generator/slugkit` directly).
- `userver-tests` uses the prebuilt image; the repo now has read access to it. Configure is Release + `libutf8proc-dev` (the image lacks utf8proc); `find_package(fmt)` precedes userver.

## Branch protection

Require **host-tests (ubuntu)**, **host-tests (macOS)**, **compiler**, and **userver-tests**.